### PR TITLE
Ensure that configuration is usable

### DIFF
--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Twig\Exception;
+
+use DomainException;
+use Interop\Container\Exception\ContainerException;
+
+class InvalidConfigException extends DomainException implements
+    ContainerException,
+    ExceptionInterface
+{
+}

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Expressive\Twig;
 
+use ArrayObject;
 use Interop\Container\ContainerInterface;
 use Twig_Environment as TwigEnvironment;
 use Twig_Extension_Debug as TwigExtensionDebug;
@@ -141,11 +142,22 @@ class TwigRendererFactory
      * if present, and then returns the merged result, with those from the twig
      * array having precedence.
      *
-     * @param array $config
+     * @param array|ArrayObject $config
      * @return array
+     * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
+     *     $config is received.
      */
-    private function mergeConfig(array $config)
+    private function mergeConfig($config)
     {
+        $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
+
+        if (! is_array($config)) {
+            throw new Exception\InvalidConfigException(sprintf(
+                'config service MUST be an array or ArrayObject; received %s',
+                is_object($config) ? get_class($config) : gettype($config)
+            ));
+        }
+
         $expressiveConfig = (isset($config['templates']) && is_array($config['templates']))
             ? $config['templates']
             : [];

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -14,6 +14,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplatePath;
+use Zend\Expressive\Twig\Exception\InvalidConfigException;
 use Zend\Expressive\Twig\Exception\InvalidExtensionException;
 use Zend\Expressive\Twig\TwigExtension;
 use Zend\Expressive\Twig\TwigRenderer;
@@ -310,6 +311,37 @@ class TwigRendererFactoryTest extends TestCase
         $factory = new TwigRendererFactory();
 
         $this->setExpectedException(InvalidExtensionException::class);
+        $factory($this->container->reveal());
+    }
+
+    public function invalidConfiguration()
+    {
+        // @codingStandardsIgnoreStart
+        //                        [Config value,                        Type ]
+        return [
+            'null'             => [null,                                'null'],
+            'true'             => [true,                                'boolean'],
+            'false'            => [false,                               'boolean'],
+            'zero'             => [0,                                   'integer'],
+            'int'              => [1,                                   'integer'],
+            'zero-float'       => [0.0,                                 'double'],
+            'float'            => [1.1,                                 'double'],
+            'string'           => ['not-configuration',                 'string'],
+            'non-array-object' => [(object) ['not' => 'configuration'], 'stdClass'],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @depends invalidConfiguration
+     */
+    public function testRaisesExceptionForInvalidConfigService($config, $contains)
+    {
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+
+        $factory = new TwigRendererFactory();
+        $this->setExpectedException(InvalidConfigException::class, $contains);
         $factory($this->container->reveal());
     }
 }


### PR DESCRIPTION
- If it's an ArrayObject, cast it to an array
- If we still don't have an array, raise a container exception

(Discovered when doing an integration test.)
