### PR TITLE
Fix a skipped test

### DIFF
--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -53,10 +53,20 @@ class TwigRendererFactory
     /**
      * @param ContainerInterface $container
      * @return TwigRenderer
+     * @throws Exception\InvalidConfigException for invalid config service values.
      */
     public function __invoke(ContainerInterface $container)
     {
         $config   = $container->has('config') ? $container->get('config') : [];
+
+        if (! is_array($config) && ! $config instanceof ArrayObject) {
+            throw new Exception\InvalidConfigException(sprintf(
+                '"config" service must be an array or ArrayObject for the %s to be able to consume it; received %s',
+                __CLASS__,
+                (is_object($config) ? get_class($config) : gettype($config))
+            ));
+        }
+
         $debug    = array_key_exists('debug', $config) ? (bool) $config['debug'] : false;
         $config   = $this->mergeConfig($config);
         $cacheDir = isset($config['cache_dir']) ? $config['cache_dir'] : false;

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -319,7 +319,6 @@ class TwigRendererFactoryTest extends TestCase
         // @codingStandardsIgnoreStart
         //                        [Config value,                        Type ]
         return [
-            'null'             => [null,                                'null'],
             'true'             => [true,                                'boolean'],
             'false'            => [false,                               'boolean'],
             'zero'             => [0,                                   'integer'],
@@ -333,7 +332,7 @@ class TwigRendererFactoryTest extends TestCase
     }
 
     /**
-     * @depends invalidConfiguration
+     * @dataProvider invalidConfiguration
      */
     public function testRaisesExceptionForInvalidConfigService($config, $contains)
     {


### PR DESCRIPTION
The test `TwigRendererFactoryTest::testRaisesExceptionForInvalidConfigService` was being skipped because it erroneously defined a `@depends` annotation instead of a `@dataProvider` annotation. Once that was resolved, the test demonstrated that the code was not throwing an expected exception, so a change was introduced to do so.
