### PR TITLE
Add config globals to be passed to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#8](https://github.com/zendframework/zend-expressive-twigrenderer/pull/8)
+  adds `zendframework/zend-expressive-helpers` as a dependency, in order to
+  consume its `UrlHelper` and `ServerUrlHelper` implementations.
+  And adds the ``url`` and ``absolute_url`` twig functions to generate
+  absolute urls for a route and path.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,27 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#8](https://github.com/zendframework/zend-expressive-twigrenderer/pull/8)
   adds `zendframework/zend-expressive-helpers` as a dependency, in order to
   consume its `UrlHelper` and `ServerUrlHelper` implementations.
-  And adds the ``url`` and ``absolute_url`` twig functions to generate
+
+  Adds the ``url`` and ``absolute_url`` twig functions to generate
   absolute urls for a route and path.
+
+- [#10](https://github.com/zendframework/zend-expressive-twigrenderer/pull/10)
+  adds config globals being passed to twig templates.
+
+  ```php
+  'twig' => [
+     'cache_dir' => 'path to cached templates',
+     'assets_url' => 'base URL for assets',
+     'assets_version' => 'base version for assets',
+     'extensions' => [
+         // extension service names or instances
+     ],
+     'globals' => [
+         // Global variables passed to twig templates
+         'ga_tracking' => 'UA-XXXXX-X'
+     ],
+  ],
+  ```
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -30,18 +30,21 @@ The included Twig extension adds support for url generation. The extension is au
 container.
 
 - ``path``: Render the relative path for a given route and parameters.
+  If there is no route, it returns the current path.
 
   ```twig
   {{ path('article_show', {'id': '3'}) }}
   Generates: /article/3
   ```
 - ``url``: Render the absolute url for a given route and parameters.
+  If there is no route, it returns the current url.
 
   ```twig
   {{ url('article_show', {'slug': 'article.slug'}) }}
   Generates: http://example.com/article/article.slug
   ```
-- ``absolute_url``: Render the absolute url from a given path. If the path is empty, it returns the current url.
+- ``absolute_url``: Render the absolute url from a given path.
+  If the path is empty, it returns the current url.
 
   ```twig
   {{ absolute_url('path/to/something') }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,44 @@ can recommend the following implementations:
   `composer require mouf/pimple-interop`
 - [Aura.Di](https://github.com/auraphp/Aura.Di)
 
+## Twig Extension
+
+The included Twig extension adds support for url generation. The extension is automatically activated if the
+[UrlHelper](https://github.com/zendframework/zend-expressive-helpers#urlhelper) and
+[ServerUrlHelper](https://github.com/zendframework/zend-expressive-helpers#serverurlhelper) are registered with the
+container.
+
+- ``path``: Render the relative path for a given route and parameters.
+
+  ```twig
+  {{ path('article_show', {'id': '3'}) }}
+  Generates: /article/3
+  ```
+- ``url``: Render the absolute url for a given route and parameters.
+
+  ```twig
+  {{ url('article_show', {'slug': 'article.slug'}) }}
+  Generates: http://example.com/article/article.slug
+  ```
+- ``absolute_url``: Render the absolute url from a given path. If the path is empty, it returns the current url.
+
+  ```twig
+  {{ absolute_url('path/to/something') }}
+  Generates: http://example.com/path/to/something
+  ```
+- ``asset`` Render an optionally versioned asset url.
+
+  ```twig
+  {{ asset('path/to/asset/name.ext', version=3) }}
+  Generates: path/to/asset/name.ext?v=3
+  ```
+
+  To get the absolute url for an asset:
+  ```twig
+  {{ absolute_url(asset('path/to/asset/name.ext', version=3)) }}
+  Generates: http://example.com/path/to/asset/name.ext?v=3
+  ```
+
 ## Documentation
 
 See the [zend-expressive](https://github.com/zendframework/zend-expressive/blob/master/doc/book)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,32 @@ container.
   Generates: http://example.com/path/to/asset/name.ext?v=3
   ```
 
+## Configuration
+
+```php
+'templates' => [
+    'extension' => 'file extension used by templates; defaults to html.twig',
+    'paths' => [
+        // namespace / path pairs
+        //
+        // Numeric namespaces imply the default/main namespace. Paths may be
+        // strings or arrays of string paths to associate with the namespace.
+    ],
+],
+'twig' => [
+    'cache_dir' => 'path to cached templates',
+    'assets_url' => 'base URL for assets',
+    'assets_version' => 'base version for assets',
+    'extensions' => [
+        // extension service names or instances
+    ],
+    'globals' => [
+        // Global variables passed to twig templates
+        'ga_tracking' => 'UA-XXXXX-X'
+    ],
+],
+```
+
 ## Documentation
 
 See the [zend-expressive](https://github.com/zendframework/zend-expressive/blob/master/doc/book)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "twig/twig": "^1.19",
-        "zendframework/zend-expressive-router": "^1.0",
+        "zendframework/zend-expressive-helpers": "^1.1 || ^2.0",
         "zendframework/zend-expressive-template": "^1.0"
     },
     "require-dev": {

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -11,7 +11,8 @@ namespace Zend\Expressive\Twig;
 
 use Twig_Extension;
 use Twig_SimpleFunction;
-use Zend\Expressive\Router\RouterInterface;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
 
 /**
  * Twig extension for rendering URLs and assets URLs from Expressive.
@@ -21,9 +22,14 @@ use Zend\Expressive\Router\RouterInterface;
 class TwigExtension extends Twig_Extension
 {
     /**
-     * @var RouterInterface
+     * @var ServerUrlHelper
      */
-    private $router;
+    private $serverUrlHelper;
+
+    /**
+     * @var UrlHelper
+     */
+    private $urlHelper;
 
     /**
      * @var string
@@ -36,18 +42,21 @@ class TwigExtension extends Twig_Extension
     private $assetsVersion;
 
     /**
-     * @param RouterInterface $router
-     * @param string $assetsUrl
-     * @param string $assetsVersion
+     * @param ServerUrlHelper $serverUrlHelper
+     * @param UrlHelper       $urlHelper
+     * @param string          $assetsUrl
+     * @param string          $assetsVersion
      */
     public function __construct(
-        RouterInterface $router,
+        ServerUrlHelper $serverUrlHelper,
+        UrlHelper $urlHelper,
         $assetsUrl,
         $assetsVersion
     ) {
-        $this->router        = $router;
-        $this->assetsUrl     = $assetsUrl;
-        $this->assetsVersion = $assetsVersion;
+        $this->serverUrlHelper = $serverUrlHelper;
+        $this->urlHelper       = $urlHelper;
+        $this->assetsUrl       = $assetsUrl;
+        $this->assetsVersion   = $assetsVersion;
     }
 
     /**
@@ -72,14 +81,19 @@ class TwigExtension extends Twig_Extension
     /**
      * Usage: {{ path('name', parameters) }}
      *
-     * @param $name
-     * @param array $parameters
-     * @param bool $relative
+     * @param null  $route
+     * @param array $params
+     *
      * @return string
      */
-    public function renderUri($name, $parameters = [], $relative = false)
+    public function renderUri($route = null, $params = [])
     {
-        return $this->router->generateUri($name, $parameters);
+        return $this->urlHelper->generate($route, $params);
+    }
+
+    public function renderAbsoluteUrl($route = null, $params = [])
+    {
+        return $this->urlHelper->generate($route, $params);
     }
 
     /**

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -115,7 +115,7 @@ class TwigExtension extends Twig_Extension
     /**
      * Render absolute url from a path
      *
-     * Usage: {{ absoulte_url('path/to/something') }}
+     * Usage: {{ absolute_url('path/to/something') }}
      * Generates: http://example.com/path/to/something
      *
      * @param $path
@@ -128,7 +128,10 @@ class TwigExtension extends Twig_Extension
     }
 
     /**
+     * Render asset url, optionally versioned
+     *
      * Usage: {{ asset('path/to/asset/name.ext', version=3) }}
+     * Generates: path/to/asset/name.ext?v=3
      *
      * @param $path
      * @param null $version

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -42,21 +42,29 @@ class TwigExtension extends Twig_Extension
     private $assetsVersion;
 
     /**
+     * @var array
+     */
+    private $globals;
+
+    /**
      * @param ServerUrlHelper $serverUrlHelper
      * @param UrlHelper       $urlHelper
      * @param string          $assetsUrl
      * @param string          $assetsVersion
+     * @param array           $globals
      */
     public function __construct(
         ServerUrlHelper $serverUrlHelper,
         UrlHelper $urlHelper,
         $assetsUrl,
-        $assetsVersion
+        $assetsVersion,
+        array $globals = []
     ) {
         $this->serverUrlHelper = $serverUrlHelper;
         $this->urlHelper       = $urlHelper;
         $this->assetsUrl       = $assetsUrl;
         $this->assetsVersion   = $assetsVersion;
+        $this->globals         = $globals;
     }
 
     /**
@@ -65,6 +73,11 @@ class TwigExtension extends Twig_Extension
     public function getName()
     {
         return 'zend-expressive';
+    }
+
+    public function getGlobals()
+    {
+        return $this->globals;
     }
 
     /**

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -73,16 +73,18 @@ class TwigExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
+            new Twig_SimpleFunction('absolute_url', [$this, 'generateUrlFromPath']),
+            new Twig_SimpleFunction('asset', [$this, 'renderAssetUrl']),
             new Twig_SimpleFunction('path', [$this, 'renderUri']),
             new Twig_SimpleFunction('url', [$this, 'renderUrl']),
-            new Twig_SimpleFunction('asset', [$this, 'renderAssetUrl']),
         ];
     }
 
     /**
-     * Render relative uri
+     * Render relative uri for a given named route
      *
-     * Usage: {{ path('name', parameters) }}
+     * Usage: {{ path('article_show', {'id': '3'}) }}
+     * Generates: /article/3
      *
      * @param null  $route
      * @param array $params
@@ -95,9 +97,10 @@ class TwigExtension extends Twig_Extension
     }
 
     /**
-     * Render absolute url
+     * Render absolute url for a given named route
      *
-     * Usage: {{ url('article_show', {'slug': article.slug}) }}
+     * Usage: {{ url('article_show', {'slug': 'article.slug'}) }}
+     * Generates: http://example.com/article/article.slug
      *
      * @param null  $route
      * @param array $params
@@ -107,6 +110,21 @@ class TwigExtension extends Twig_Extension
     public function renderUrl($route = null, $params = [])
     {
         return $this->serverUrlHelper->generate($this->urlHelper->generate($route, $params));
+    }
+
+    /**
+     * Generate absolute url from a path
+     *
+     * Usage: {{ absoulte_url('path/to/something') }}
+     * Generates: http://example.com/path/to/something
+     *
+     * @param $path
+     *
+     * @return string
+     */
+    public function generateUrlFromPath($path)
+    {
+        return $this->serverUrlHelper->generate($path);
     }
 
     /**

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -74,11 +74,14 @@ class TwigExtension extends Twig_Extension
     {
         return [
             new Twig_SimpleFunction('path', [$this, 'renderUri']),
+            new Twig_SimpleFunction('url', [$this, 'renderUrl']),
             new Twig_SimpleFunction('asset', [$this, 'renderAssetUrl']),
         ];
     }
 
     /**
+     * Render relative uri
+     *
      * Usage: {{ path('name', parameters) }}
      *
      * @param null  $route
@@ -91,9 +94,19 @@ class TwigExtension extends Twig_Extension
         return $this->urlHelper->generate($route, $params);
     }
 
-    public function renderAbsoluteUrl($route = null, $params = [])
+    /**
+     * Render absolute url
+     *
+     * Usage: {{ url('article_show', {'slug': article.slug}) }}
+     *
+     * @param null  $route
+     * @param array $params
+     *
+     * @return string
+     */
+    public function renderUrl($route = null, $params = [])
     {
-        return $this->urlHelper->generate($route, $params);
+        return $this->serverUrlHelper->generate($this->urlHelper->generate($route, $params));
     }
 
     /**

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -122,7 +122,7 @@ class TwigExtension extends Twig_Extension
      *
      * @return string
      */
-    public function renderUrlFromPath($path)
+    public function renderUrlFromPath($path = null)
     {
         return $this->serverUrlHelper->generate($path);
     }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -73,7 +73,7 @@ class TwigExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('absolute_url', [$this, 'generateUrlFromPath']),
+            new Twig_SimpleFunction('absolute_url', [$this, 'renderUrlFromPath']),
             new Twig_SimpleFunction('asset', [$this, 'renderAssetUrl']),
             new Twig_SimpleFunction('path', [$this, 'renderUri']),
             new Twig_SimpleFunction('url', [$this, 'renderUrl']),
@@ -113,7 +113,7 @@ class TwigExtension extends Twig_Extension
     }
 
     /**
-     * Generate absolute url from a path
+     * Render absolute url from a path
      *
      * Usage: {{ absoulte_url('path/to/something') }}
      * Generates: http://example.com/path/to/something
@@ -122,7 +122,7 @@ class TwigExtension extends Twig_Extension
      *
      * @return string
      */
-    public function generateUrlFromPath($path)
+    public function renderUrlFromPath($path)
     {
         return $this->serverUrlHelper->generate($path);
     }

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -15,7 +15,8 @@ use Twig_Environment as TwigEnvironment;
 use Twig_Extension_Debug as TwigExtensionDebug;
 use Twig_ExtensionInterface;
 use Twig_Loader_Filesystem as TwigLoader;
-use Zend\Expressive\Router\RouterInterface;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
 
 /**
  * Create and return a Twig template instance.
@@ -80,15 +81,17 @@ class TwigRendererFactory
             'auto_reload'      => $debug
         ]);
 
-        // Add extensions
-        if ($container->has(RouterInterface::class)) {
+        // Add expressive twig extension
+        if ($container->has(ServerUrlHelper::class) && $container->has(UrlHelper::class)) {
             $environment->addExtension(new TwigExtension(
-                $container->get(RouterInterface::class),
+                $container->get(ServerUrlHelper::class),
+                $container->get(UrlHelper::class),
                 isset($config['assets_url']) ? $config['assets_url'] : '',
                 isset($config['assets_version']) ? $config['assets_version'] : ''
             ));
         }
 
+        // Add debug extension
         if ($debug) {
             $environment->addExtension(new TwigExtensionDebug());
         }

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -42,6 +42,10 @@ use Zend\Expressive\Helper\UrlHelper;
  *     'extensions' => [
  *         // extension service names or instances
  *     ],
+ *     'globals' => [
+ *         // Global variables passed to twig templates
+ *         'ga_tracking' => 'UA-XXXXX-X'
+ *     ],
  * ],
  * </code>
  *
@@ -87,7 +91,8 @@ class TwigRendererFactory
                 $container->get(ServerUrlHelper::class),
                 $container->get(UrlHelper::class),
                 isset($config['assets_url']) ? $config['assets_url'] : '',
-                isset($config['assets_version']) ? $config['assets_version'] : ''
+                isset($config['assets_version']) ? $config['assets_version'] : '',
+                isset($config['globals']) ? $config['globals'] : []
             ));
         }
 

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -12,7 +12,8 @@ namespace ZendTest\Expressive\Twig;
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
-use Zend\Expressive\Router\RouterInterface;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Template\TemplatePath;
 use Zend\Expressive\Twig\Exception\InvalidConfigException;
 use Zend\Expressive\Twig\Exception\InvalidExtensionException;
@@ -103,7 +104,8 @@ class TwigRendererFactoryTest extends TestCase
     public function testCallingFactoryWithNoConfigReturnsTwigInstance()
     {
         $this->container->has('config')->willReturn(false);
-        $this->container->has(RouterInterface::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigRendererFactory();
         $twig = $factory($this->container->reveal());
         $this->assertInstanceOf(TwigRenderer::class, $twig);
@@ -125,7 +127,8 @@ class TwigRendererFactoryTest extends TestCase
         $config = ['debug' => true];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
-        $this->container->has(RouterInterface::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigRendererFactory();
         $twig = $factory($this->container->reveal());
 
@@ -154,7 +157,8 @@ class TwigRendererFactoryTest extends TestCase
         $config = ['templates' => ['cache_dir' => __DIR__]];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
-        $this->container->has(RouterInterface::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigRendererFactory();
         $twig = $factory($this->container->reveal());
 
@@ -164,10 +168,14 @@ class TwigRendererFactoryTest extends TestCase
 
     public function testAddsTwigExtensionIfRouterIsInContainer()
     {
-        $router = $this->prophesize(RouterInterface::class)->reveal();
+        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
+        $urlHelper = $this->prophesize(UrlHelper::class)->reveal();
         $this->container->has('config')->willReturn(false);
-        $this->container->has(RouterInterface::class)->willReturn(true);
-        $this->container->get(RouterInterface::class)->willReturn($router);
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
+
         $factory = new TwigRendererFactory();
         $twig = $factory($this->container->reveal());
 
@@ -183,11 +191,14 @@ class TwigRendererFactoryTest extends TestCase
                 'assets_version' => 'XYZ',
             ],
         ];
-        $router = $this->prophesize(RouterInterface::class)->reveal();
+        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
+        $urlHelper = $this->prophesize(UrlHelper::class)->reveal();
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
-        $this->container->has(RouterInterface::class)->willReturn(true);
-        $this->container->get(RouterInterface::class)->willReturn($router);
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
         $factory = new TwigRendererFactory();
         $twig = $factory($this->container->reveal());
 
@@ -196,7 +207,8 @@ class TwigRendererFactoryTest extends TestCase
         $this->assertInstanceOf(TwigExtension::class, $extension);
         $this->assertAttributeEquals($config['templates']['assets_url'], 'assetsUrl', $extension);
         $this->assertAttributeEquals($config['templates']['assets_version'], 'assetsVersion', $extension);
-        $this->assertAttributeSame($router, 'router', $extension);
+        $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $extension);
+        $this->assertAttributeSame($urlHelper, 'urlHelper', $extension);
     }
 
     public function testConfiguresTemplateSuffix()
@@ -208,7 +220,8 @@ class TwigRendererFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
-        $this->container->has(RouterInterface::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigRendererFactory();
         $twig = $factory($this->container->reveal());
 
@@ -224,7 +237,8 @@ class TwigRendererFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
-        $this->container->has(RouterInterface::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigRendererFactory();
         $twig = $factory($this->container->reveal());
 
@@ -259,7 +273,8 @@ class TwigRendererFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
-        $this->container->has(RouterInterface::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
         $this->container->has(BarTwigExtension::class)->willReturn(true);
         $this->container->get(BarTwigExtension::class)->willReturn(new BarTwigExtension());
         $factory = new TwigRendererFactory();
@@ -302,7 +317,8 @@ class TwigRendererFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
-        $this->container->has(RouterInterface::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
 
         if (is_string($extension)) {
             $this->container->has($extension)->willReturn(false);

--- a/test/TwigRendererTest.php
+++ b/test/TwigRendererTest.php
@@ -71,9 +71,9 @@ class TwigRendererTest extends TestCase
 
     public function testShouldInjectDefaultLoaderIfProvidedEnvironmentDoesNotComposeOne()
     {
-        $twigEnvironment  = new Twig_Environment();
-        $renderer = new TwigRenderer($twigEnvironment);
-        $loader           = $twigEnvironment->getLoader();
+        $twigEnvironment = new Twig_Environment();
+        $renderer        = new TwigRenderer($twigEnvironment);
+        $loader          = $twigEnvironment->getLoader();
         $this->assertInstanceOf('Twig_Loader_Filesystem', $loader);
     }
 


### PR DESCRIPTION
This adds an extra twig globals config option which are passed to the templates.

``` php
'twig' => [
    'globals' => [
        // Global variables passed to twig templates
        'ga_tracking' => 'UA-XXXXX-X'
    ],
],
```
- [x] Add passing globals feature.
- [x] Add documentation.
- [x] Update changelog.
- [x] Add tests.
