### PR TITLE
Fixed: added "Twig_Extension_GlobalsInterface" to "Zend\Expressive\Tw…

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -19,7 +19,7 @@ use Zend\Expressive\Helper\UrlHelper;
  *
  * @author Geert Eltink (https://xtreamwayz.github.io)
  */
-class TwigExtension extends Twig_Extension
+class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     /**
      * @var ServerUrlHelper


### PR DESCRIPTION
Defining the getGlobals() method in the twig extension without explicitly implementing Twig_Extension_GlobalsInterface is deprecated since version 1.23.
Otherwise the twig library will trigger an error.
