### PR TITLE
Add support for specifying default timezone for twig's date() filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ container.
         // Global variables passed to twig templates
         'ga_tracking' => 'UA-XXXXX-X'
     ],
+    'timezone' => 'default timezone identifier, e.g.: America/New_York'
 ],
 ```
 

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -17,6 +17,7 @@ use Twig_ExtensionInterface;
 use Twig_Loader_Filesystem as TwigLoader;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Twig\Exception\InvalidConfigException;
 
 /**
  * Create and return a Twig template instance.
@@ -46,6 +47,7 @@ use Zend\Expressive\Helper\UrlHelper;
  *         // Global variables passed to twig templates
  *         'ga_tracking' => 'UA-XXXXX-X'
  *     ],
+ *     'timezone' => 'default timezone identifier, e.g.: America/New_York'
  * ],
  * </code>
  *
@@ -84,6 +86,19 @@ class TwigRendererFactory
             'strict_variables' => $debug,
             'auto_reload'      => $debug
         ]);
+
+        if (isset($config['timezone'])) {
+            $timezone = $config['timezone'];
+            if (! is_string($timezone)) {
+                throw new InvalidConfigException('"timezone" configuration value must be a string');
+            }
+            try {
+                $timezone = new \DateTimeZone($timezone);
+            } catch (\Exception $e) {
+                throw new InvalidConfigException("Unknown or invalid timezone: '{$timezone}'");
+            }
+            $environment->getExtension('core')->setTimezone($timezone);
+        }
 
         // Add expressive twig extension
         if ($container->has(ServerUrlHelper::class) && $container->has(UrlHelper::class)) {

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -291,7 +291,7 @@ class TwigRendererFactoryTest extends TestCase
     {
         $tz = \DateTimeZone::listIdentifiers()[0];
         $config = [
-            'templates' => [
+            'twig' => [
                 'timezone' => $tz
             ]
         ];
@@ -310,7 +310,7 @@ class TwigRendererFactoryTest extends TestCase
     {
         $tz = 'Luna/Copernicus_Crater';
         $config = [
-            'templates' => [
+            'twig' => [
                 'timezone' => $tz
             ]
         ];

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -287,6 +287,42 @@ class TwigRendererFactoryTest extends TestCase
         $this->assertInstanceOf(BarTwigExtension::class, $environment->getExtension('bar-twig-extension'));
     }
 
+    public function testUsesTimezoneConfiguration()
+    {
+        $tz = \DateTimeZone::listIdentifiers()[0];
+        $config = [
+            'templates' => [
+                'timezone' => $tz
+            ]
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
+        $factory = new TwigRendererFactory();
+        $twig = $factory($this->container->reveal());
+        $environment = $this->fetchTwigEnvironment($twig);
+        $fetchedTz = $environment->getExtension('core')->getTimezone();
+        $this->assertEquals(new \DateTimeZone($tz), $fetchedTz);
+    }
+
+    public function testRaisesExceptionForInvalidTimezone()
+    {
+        $tz = 'Luna/Copernicus_Crater';
+        $config = [
+            'templates' => [
+                'timezone' => $tz
+            ]
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
+        $factory = new TwigRendererFactory();
+        $this->setExpectedException(InvalidConfigException::class);
+        $factory($this->container->reveal());
+    }
+
     public function invalidExtensions()
     {
         return [


### PR DESCRIPTION
This adds support for configuring twig's default timezone via configuration.

``` php
'twig' => [
    'timezone' => 'Europe/Paris'
]
```
