### PR TITLE
Add query params, fragment and reuse route result

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ can recommend the following implementations:
 
 The included Twig extension adds support for url generation. The extension is automatically activated if the
 [UrlHelper](https://github.com/zendframework/zend-expressive-helpers#urlhelper) and
-[ServerUrlHelper](https://github.com/zendframework/zend-expressive-helpers#serverurlhelper) are registered with the
-container.
+[ServerUrlHelper](https://github.com/zendframework/zend-expressive-helpers#serverurlhelper) 
+are registered with the container.
 
 - ``path``: Render the relative path for a given route and parameters. If there
   is no route, it returns the current path.
@@ -36,6 +36,20 @@ container.
   {{ path('article_show', {'id': '3'}) }}
   Generates: /article/3
   ```
+  
+  ``path`` supports optional query parameters and a fragment identifier.
+
+  ```twig
+  {{ path('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
+  Generates: /article/3?foo=bar#fragment
+  ```
+
+  By default the current route result is used where applicable. To disable this
+  the `reuse_result_params` option can be set.
+
+  ```twig
+  {{ path('article_show', {}, {}, null, {'reuse_result_params': false}) }}
+  ```
 
 - ``url``: Render the absolute url for a given route and parameters. If there is
   no route, it returns the current url.
@@ -43,6 +57,20 @@ container.
   ```twig
   {{ url('article_show', {'slug': 'article.slug'}) }}
   Generates: http://example.com/article/article.slug
+  ```
+
+  ``url`` also supports query parameters and a fragment identifier.
+
+  ```twig
+  {{ url('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
+  Generates: http://example.com/article/3?foo=bar#fragment
+  ```
+
+  By default the current route result is used where applicable. To disable this
+  the `reuse_result_params` option can be set.
+
+  ```twig
+  {{ url('article_show', {}, {}, null, {'reuse_result_params': false}) }}
   ```
 
 - ``absolute_url``: Render the absolute url from a given path. If the path is

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "twig/twig": "^1.19",
-        "zendframework/zend-expressive-helpers": "^1.1 || ^2.0",
+        "zendframework/zend-expressive-helpers": "^3.0.0-dev",
+        "zendframework/zend-expressive-router": "^2.0.0-dev",
         "zendframework/zend-expressive-template": "^1.0"
     },
     "require-dev": {

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -103,26 +103,25 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Generates: /article/3?foo=bar#fragment
      *
      * @param null|string $route
-     * @param array       $params
-     * @param array       $query
-     * @param null|string $fragment
+     * @param array       $routeParams
+     * @param array       $queryParams
+     * @param null        $fragmentIdentifier
      * @param bool        $reuseResultParams
      *
      * @return string
      */
-    public function renderUri($route = null, $params = [], $query = [], $fragment = null, $reuseResultParams = true)
-    {
-        $routeParams = [
-            'route'    => $params,
-            'query'    => $query,
-            'fragment' => $fragment,
-        ];
-
+    public function renderUri(
+        $route = null,
+        $routeParams = [],
+        $queryParams = [],
+        $fragmentIdentifier = null,
+        $reuseResultParams = true
+    ) {
         $options = [
             'reuse_result_params' => (bool) $reuseResultParams,
         ];
 
-        return $this->urlHelper->generate($route, $routeParams, $options);
+        return $this->urlHelper->generate($route, $routeParams, $queryParams, $fragmentIdentifier, $options);
     }
 
     /**
@@ -135,23 +134,27 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Generates: http://example.com/article/3?foo=bar#fragment
      *
      * @param null  $route
-     * @param array $params
+     * @param array $routeParams
+     * @param array $queryParams
+     * @param null  $fragmentIdentifier
+     * @param bool  $reuseResultParams
      *
      * @return string
      */
-    public function renderUrl($route = null, $params = [], $query = [], $fragment = null, $reuseResultParams = true)
-    {
-        $routeParams = [
-            'route'    => $params,
-            'query'    => $query,
-            'fragment' => $fragment,
-        ];
-
+    public function renderUrl(
+        $route = null,
+        $routeParams = [],
+        $queryParams = [],
+        $fragmentIdentifier = null,
+        $reuseResultParams = true
+    ) {
         $options = [
             'reuse_result_params' => (bool) $reuseResultParams,
         ];
 
-        return $this->serverUrlHelper->generate($this->urlHelper->generate($route, $routeParams, $options));
+        return $this->serverUrlHelper->generate(
+            $this->urlHelper->generate($route, $routeParams, $queryParams, $fragmentIdentifier, $options)
+        );
     }
 
     /**

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -106,7 +106,9 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * @param array       $routeParams
      * @param array       $queryParams
      * @param null|string $fragmentIdentifier
-     * @param bool        $reuseResultParams
+     * @param array       $options      Can have the following keys:
+     *                                  - reuse_result_params (bool): indicates if the current
+     *                                  RouteResult parameters will be used, defaults to true
      *
      * @return string
      */
@@ -115,12 +117,8 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
         $routeParams = [],
         $queryParams = [],
         $fragmentIdentifier = null,
-        $reuseResultParams = true
+        array $options = []
     ) {
-        $options = [
-            'reuse_result_params' => (bool) $reuseResultParams,
-        ];
-
         return $this->urlHelper->generate($route, $routeParams, $queryParams, $fragmentIdentifier, $options);
     }
 
@@ -137,7 +135,9 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * @param array       $routeParams
      * @param array       $queryParams
      * @param null|string $fragmentIdentifier
-     * @param bool        $reuseResultParams
+     * @param array       $options      Can have the following keys:
+     *                                  - reuse_result_params (bool): indicates if the current
+     *                                  RouteResult parameters will be used, defaults to true
      *
      * @return string
      */
@@ -146,12 +146,8 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
         $routeParams = [],
         $queryParams = [],
         $fragmentIdentifier = null,
-        $reuseResultParams = true
+        array $options = []
     ) {
-        $options = [
-            'reuse_result_params' => (bool) $reuseResultParams,
-        ];
-
         return $this->serverUrlHelper->generate(
             $this->urlHelper->generate($route, $routeParams, $queryParams, $fragmentIdentifier, $options)
         );

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -99,14 +99,26 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Usage: {{ path('article_show', {'id': '3'}) }}
      * Generates: /article/3
      *
-     * @param null  $route
+     * Usage: {{ path('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
+     * Generates: /article/3?foo=bar#fragment
+     *
+     * @param null|string  $route
      * @param array $params
+     * @param array $query
+     * @param null|string  $fragment
+     * @param bool  $reuseResultParams
      *
      * @return string
      */
-    public function renderUri($route = null, $params = [])
+    public function renderUri($route = null, $params = [], $query = [], $fragment = null)
     {
-        return $this->urlHelper->generate($route, $params);
+        $routeParams = [
+            'route' => $params,
+            'query' => $query,
+            'fragment' => $fragment,
+        ];
+
+        return $this->urlHelper->generate($route, $routeParams);
     }
 
     /**
@@ -115,14 +127,23 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Usage: {{ url('article_show', {'slug': 'article.slug'}) }}
      * Generates: http://example.com/article/article.slug
      *
+     * Usage: {{ path('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
+     * Generates: http://example.com/article/3?foo=bar#fragment
+     *
      * @param null  $route
      * @param array $params
      *
      * @return string
      */
-    public function renderUrl($route = null, $params = [])
+    public function renderUrl($route = null, $params = [], $query = [], $fragment = null)
     {
-        return $this->serverUrlHelper->generate($this->urlHelper->generate($route, $params));
+        $routeParams = [
+            'route' => $params,
+            'query' => $query,
+            'fragment' => $fragment,
+        ];
+
+        return $this->serverUrlHelper->generate($this->urlHelper->generate($route, $routeParams));
     }
 
     /**

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -105,7 +105,7 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * @param null|string $route
      * @param array       $routeParams
      * @param array       $queryParams
-     * @param null        $fragmentIdentifier
+     * @param null|string $fragmentIdentifier
      * @param bool        $reuseResultParams
      *
      * @return string
@@ -133,11 +133,11 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Usage: {{ path('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
      * Generates: http://example.com/article/3?foo=bar#fragment
      *
-     * @param null  $route
-     * @param array $routeParams
-     * @param array $queryParams
-     * @param null  $fragmentIdentifier
-     * @param bool  $reuseResultParams
+     * @param null|string $route
+     * @param array       $routeParams
+     * @param array       $queryParams
+     * @param null|string $fragmentIdentifier
+     * @param bool        $reuseResultParams
      *
      * @return string
      */

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -17,7 +17,7 @@ use Zend\Expressive\Helper\UrlHelper;
 /**
  * Twig extension for rendering URLs and assets URLs from Expressive.
  *
- * @author Geert Eltink (https://xtreamwayz.github.io)
+ * @author Geert Eltink (https://xtreamwayz.com)
  */
 class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
@@ -130,7 +130,7 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Usage: {{ url('article_show', {'slug': 'article.slug'}) }}
      * Generates: http://example.com/article/article.slug
      *
-     * Usage: {{ path('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
+     * Usage: {{ url('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
      * Generates: http://example.com/article/3?foo=bar#fragment
      *
      * @param null|string $route
@@ -178,8 +178,8 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Usage: {{ asset('path/to/asset/name.ext', version=3) }}
      * Generates: path/to/asset/name.ext?v=3
      *
-     * @param      $path
-     * @param null $version
+     * @param string $path
+     * @param null   $version
      *
      * @return string
      */

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -102,23 +102,27 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Usage: {{ path('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
      * Generates: /article/3?foo=bar#fragment
      *
-     * @param null|string  $route
-     * @param array $params
-     * @param array $query
-     * @param null|string  $fragment
-     * @param bool  $reuseResultParams
+     * @param null|string $route
+     * @param array       $params
+     * @param array       $query
+     * @param null|string $fragment
+     * @param bool        $reuseResultParams
      *
      * @return string
      */
-    public function renderUri($route = null, $params = [], $query = [], $fragment = null)
+    public function renderUri($route = null, $params = [], $query = [], $fragment = null, $reuseResultParams = true)
     {
         $routeParams = [
-            'route' => $params,
-            'query' => $query,
+            'route'    => $params,
+            'query'    => $query,
             'fragment' => $fragment,
         ];
 
-        return $this->urlHelper->generate($route, $routeParams);
+        $options = [
+            'reuse_result_params' => (bool) $reuseResultParams,
+        ];
+
+        return $this->urlHelper->generate($route, $routeParams, $options);
     }
 
     /**
@@ -135,15 +139,19 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      *
      * @return string
      */
-    public function renderUrl($route = null, $params = [], $query = [], $fragment = null)
+    public function renderUrl($route = null, $params = [], $query = [], $fragment = null, $reuseResultParams = true)
     {
         $routeParams = [
-            'route' => $params,
-            'query' => $query,
+            'route'    => $params,
+            'query'    => $query,
             'fragment' => $fragment,
         ];
 
-        return $this->serverUrlHelper->generate($this->urlHelper->generate($route, $routeParams));
+        $options = [
+            'reuse_result_params' => (bool) $reuseResultParams,
+        ];
+
+        return $this->serverUrlHelper->generate($this->urlHelper->generate($route, $routeParams, $options));
     }
 
     /**
@@ -167,8 +175,9 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Usage: {{ asset('path/to/asset/name.ext', version=3) }}
      * Generates: path/to/asset/name.ext?v=3
      *
-     * @param $path
+     * @param      $path
      * @param null $version
+     *
      * @return string
      */
     public function renderAssetUrl($path, $version = null)

--- a/test/TwigExtensionFunctionsRenderTest.php
+++ b/test/TwigExtensionFunctionsRenderTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Twig;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Twig_Environment;
+use Twig_Loader_Array;
+use Twig_LoaderInterface;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Twig\TwigExtension;
+
+class TwigExtensionFunctionsRenderTest extends TestCase
+{
+    protected $templates;
+    protected $twigLoader;
+    protected $serverUrlHelper;
+    protected $urlHelper;
+
+    protected function setUp()
+    {
+        $this->twigLoader      = $this->prophesize(Twig_LoaderInterface::class);
+        $this->serverUrlHelper = $this->prophesize(ServerUrlHelper::class);
+        $this->urlHelper       = $this->prophesize(UrlHelper::class);
+
+        $this->templates = [
+            'template' => "{{ path('route') }}",
+        ];
+    }
+
+    /**
+     * @return Twig_Environment
+     */
+    protected function getTwigEnvironment($assetsUrl = '', $assetsVersion = '')
+    {
+        $loader = new Twig_Loader_Array($this->templates);
+
+        $twig = new Twig_Environment($loader, ['debug' => true, 'cache' => false]);
+        $twig->addExtension(new TwigExtension(
+            $this->serverUrlHelper->reveal(),
+            $this->urlHelper->reveal(),
+            $assetsUrl,
+            $assetsVersion
+        ));
+
+        return $twig;
+    }
+
+    public function testEnvironmentCreation()
+    {
+        $twig = $this->getTwigEnvironment();
+
+        $this->assertInstanceOf(Twig_Environment::class, $twig);
+    }
+
+    /**
+     * @dataProvider renderPathProvider
+     */
+    public function testPathFunction(
+        $template,
+        $route,
+        array $routeParams,
+        array $queryParams,
+        $fragment,
+        array $options
+    ) {
+        $this->templates = [
+            'template' => $template,
+        ];
+
+        $this->urlHelper->generate($route, $routeParams, $queryParams, $fragment, $options)->willReturn('PATH');
+        $twig = $this->getTwigEnvironment();
+
+        $this->assertSame('PATH', $twig->render('template'));
+    }
+
+    public function renderPathProvider()
+    {
+        return [
+            'path'                => [
+                "{{ path('route', {'foo': 'bar'}) }}",
+                'route',
+                ['foo' => 'bar'],
+                [],
+                null,
+                [],
+            ],
+            'path-query'          => [
+                "{{ path('path-query', {'id': '3'}, {'foo': 'bar'}) }}",
+                'path-query',
+                ['id' => 3],
+                ['foo' => 'bar'],
+                null,
+                [],
+            ],
+            'path-query-fragment' => [
+                "{{ path('path-query-fragment', {'foo': 'bar'}, {'qux': 'quux'}, 'corge') }}",
+                'path-query-fragment',
+                ['foo' => 'bar'],
+                ['qux' => 'quux'],
+                'corge',
+                [],
+            ],
+            'path-reuse-result' => [
+                "{{ path('path-query-fragment', {}, {}, null, {'reuse_result_params': true}) }}",
+                'path-query-fragment',
+                [],
+                [],
+                null,
+                ['reuse_result_params' => true],
+            ],
+            'path-dont-reuse-result' => [
+                "{{ path('path-query-fragment', {}, {}, null, {'reuse_result_params': false}) }}",
+                'path-query-fragment',
+                [],
+                [],
+                null,
+                ['reuse_result_params' => false],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider renderUrlProvider
+     */
+    public function testUrlFunction(
+        $template,
+        $route,
+        array $routeParams,
+        array $queryParams,
+        $fragment,
+        array $options
+    ) {
+        $this->templates = [
+            'template' => $template,
+        ];
+
+        $this->urlHelper->generate($route, $routeParams, $queryParams, $fragment, $options)->willReturn('PATH');
+        $this->serverUrlHelper->generate('PATH')->willReturn('HOST/PATH');
+        $twig = $this->getTwigEnvironment();
+
+        $this->assertSame('HOST/PATH', $twig->render('template'));
+    }
+
+    public function renderUrlProvider()
+    {
+        return [
+            'path'                => [
+                "{{ url('route', {'foo': 'bar'}) }}",
+                'route',
+                ['foo' => 'bar'],
+                [],
+                null,
+                [],
+            ],
+            'path-query'          => [
+                "{{ url('path-query', {'id': '3'}, {'foo': 'bar'}) }}",
+                'path-query',
+                ['id' => 3],
+                ['foo' => 'bar'],
+                null,
+                [],
+            ],
+            'path-query-fragment' => [
+                "{{ url('path-query-fragment', {'foo': 'bar'}, {'qux': 'quux'}, 'corge') }}",
+                'path-query-fragment',
+                ['foo' => 'bar'],
+                ['qux' => 'quux'],
+                'corge',
+                [],
+            ],
+            'path-reuse-result' => [
+                "{{ url('path-query-fragment', {}, {}, null, {'reuse_result_params': true}) }}",
+                'path-query-fragment',
+                [],
+                [],
+                null,
+                ['reuse_result_params' => true],
+            ],
+            'path-dont-reuse-result' => [
+                "{{ url('path-query-fragment', {}, {}, null, {'reuse_result_params': false}) }}",
+                'path-query-fragment',
+                [],
+                [],
+                null,
+                ['reuse_result_params' => false],
+            ],
+        ];
+    }
+
+    public function testAbsoluteUrlFunction()
+    {
+        $this->templates = [
+            'template' => "{{ absolute_url('path/to/something') }}",
+        ];
+
+        $this->serverUrlHelper->generate('path/to/something')->willReturn('HOST/PATH');
+        $twig = $this->getTwigEnvironment();
+
+        $this->assertSame('HOST/PATH', $twig->render('template'));
+    }
+
+    public function testAssetFunction()
+    {
+        $this->templates = [
+            'template' => "{{ asset('path/to/asset/name.ext') }}",
+        ];
+
+        $twig = $this->getTwigEnvironment();
+
+        $this->assertSame('path/to/asset/name.ext', $twig->render('template'));
+    }
+
+    public function testVersionedAssetFunction()
+    {
+        $this->templates = [
+            'template' => "{{ asset('path/to/asset/name.ext', version=3) }}",
+        ];
+
+        $twig = $this->getTwigEnvironment();
+
+        $this->assertSame('path/to/asset/name.ext?v=3', $twig->render('template'));
+    }
+}

--- a/test/TwigExtensionTest.php
+++ b/test/TwigExtensionTest.php
@@ -96,14 +96,14 @@ class TwigExtensionTest extends TestCase
 
     public function testRenderUriDelegatesToComposedUrlHelper()
     {
-        $this->urlHelper->generate('foo', ['id' => 1])->willReturn('URL');
+        $this->urlHelper->generate('foo', ['id' => 1], [], null, ['reuse_result_params' => true])->willReturn('URL');
         $extension = $this->createExtension('', '');
         $this->assertSame('URL', $extension->renderUri('foo', ['id' => 1]));
     }
 
     public function testRenderUrlDelegatesToComposedUrlHelperAndServerUrlHelper()
     {
-        $this->urlHelper->generate('foo', ['id' => 1])->willReturn('PATH');
+        $this->urlHelper->generate('foo', ['id' => 1], [], null, ['reuse_result_params' => true])->willReturn('PATH');
         $this->serverUrlHelper->generate('PATH')->willReturn('HOST/PATH');
         $extension = $this->createExtension('', '');
         $this->assertSame('HOST/PATH', $extension->renderUrl('foo', ['id' => 1]));

--- a/test/TwigExtensionTest.php
+++ b/test/TwigExtensionTest.php
@@ -96,14 +96,14 @@ class TwigExtensionTest extends TestCase
 
     public function testRenderUriDelegatesToComposedUrlHelper()
     {
-        $this->urlHelper->generate('foo', ['id' => 1], [], null, ['reuse_result_params' => true])->willReturn('URL');
+        $this->urlHelper->generate('foo', ['id' => 1], [], null, [])->willReturn('URL');
         $extension = $this->createExtension('', '');
         $this->assertSame('URL', $extension->renderUri('foo', ['id' => 1]));
     }
 
     public function testRenderUrlDelegatesToComposedUrlHelperAndServerUrlHelper()
     {
-        $this->urlHelper->generate('foo', ['id' => 1], [], null, ['reuse_result_params' => true])->willReturn('PATH');
+        $this->urlHelper->generate('foo', ['id' => 1], [], null, [])->willReturn('PATH');
         $this->serverUrlHelper->generate('PATH')->willReturn('HOST/PATH');
         $extension = $this->createExtension('', '');
         $this->assertSame('HOST/PATH', $extension->renderUrl('foo', ['id' => 1]));


### PR DESCRIPTION
This PR adds support for query parameters, fragment and a reuse route result boolean.

``` twig
Usage: {{ path('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
Generates: http://example.com/article/3?foo=bar#fragment

Usage: {{ url('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
Generates: http://example.com/article/3?foo=bar#fragment
```
- [x] Requires zendframework/zend-expressive-helpers#27
- [x] Needs tests _(after zendframework/zend-expressive-helpers#27 is merged and final)_
- [x] Add documentation
- [x] Remove temp dependency to `zendframework/zend-expressive-router:^2.0.0-dev` once it is stable.
- [x] Change dependency to `zendframework/zend-expressive-helpers:^3.0` once it is stable.
