### PR TITLE
Remove deprecated Twig_ExtensionInterface::getName() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
-        "twig/twig": "^1.19",
+        "twig/twig": "^1.26",
         "zendframework/zend-expressive-helpers": "^1.1 || ^2.0",
         "zendframework/zend-expressive-template": "^1.0"
     },

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Zend\Expressive\Twig;
+
+use ArrayObject;
+use Interop\Container\ContainerInterface;
+use Twig_Environment as TwigEnvironment;
+use Twig_Extension_Debug as TwigExtensionDebug;
+use Twig_ExtensionInterface as TwigExtensionInterface;
+use Twig_Loader_Filesystem as TwigFilesystem;
+use Twig_Loader_Filesystem as TwigLoader;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
+
+/**
+ * Create and return a Twig Environment instance.
+ *
+ * Optionally uses the service 'config', which should return an array. This
+ * factory consumes the following structure:
+ *
+ * <code>
+ * 'debug' => boolean,
+ * 'templates' => [
+ *     'extension' => 'file extension used by templates; defaults to html.twig',
+ *     'paths' => [
+ *         // namespace / path pairs
+ *         //
+ *         // Numeric namespaces imply the default/main namespace. Paths may be
+ *         // strings or arrays of string paths to associate with the namespace.
+ *     ],
+ * ],
+ * 'twig' => [
+ *     'cache_dir' => 'path to cached templates',
+ *     'assets_url' => 'base URL for assets',
+ *     'assets_version' => 'base version for assets',
+ *     'extensions' => [
+ *         // extension service names or instances
+ *     ],
+ *     'globals' => [
+ *         // Global variables passed to twig templates
+ *         'ga_tracking' => 'UA-XXXXX-X'
+ *     ],
+ * ],
+ * </code>
+ *
+ * Note: the various keys in the `twig` configuration key can occur in either
+ * that location, or under `templates` (which was the behavior prior to 0.3.0);
+ * the two arrays are merged by the factory.
+ */
+class TwigEnvironmentFactory
+{
+    /**
+     * @param ContainerInterface $container
+     *
+     * @return TwigRenderer
+     * @throws Exception\InvalidConfigException for invalid config service values.
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+
+        if (!is_array($config) && !$config instanceof ArrayObject) {
+            throw new Exception\InvalidConfigException(sprintf(
+                '"config" service must be an array or ArrayObject for the %s to be able to consume it; received %s',
+                __CLASS__,
+                (is_object($config) ? get_class($config) : gettype($config))
+            ));
+        }
+
+        $debug    = array_key_exists('debug', $config) ? (bool) $config['debug'] : false;
+        $config   = $this->mergeConfig($config);
+        $cacheDir = isset($config['cache_dir']) ? $config['cache_dir'] : false;
+
+        // Create the engine instance
+        $loader      = new TwigLoader();
+        $environment = new TwigEnvironment($loader, [
+            'cache'            => $debug ? false : $cacheDir,
+            'debug'            => $debug,
+            'strict_variables' => $debug,
+            'auto_reload'      => $debug,
+        ]);
+
+        // Add expressive twig extension
+        if ($container->has(ServerUrlHelper::class) && $container->has(UrlHelper::class)) {
+            $environment->addExtension(new TwigExtension(
+                $container->get(ServerUrlHelper::class),
+                $container->get(UrlHelper::class),
+                isset($config['assets_url']) ? $config['assets_url'] : '',
+                isset($config['assets_version']) ? $config['assets_version'] : '',
+                isset($config['globals']) ? $config['globals'] : []
+            ));
+        }
+
+        // Add debug extension
+        if ($debug) {
+            $environment->addExtension(new TwigExtensionDebug());
+        }
+
+        // Add user defined extensions
+        $extensions = (isset($config['extensions']) && is_array($config['extensions']))
+            ? $config['extensions']
+            : [];
+        $this->injectExtensions($environment, $container, $extensions);
+
+        // Add template paths
+        $allPaths = isset($config['paths']) && is_array($config['paths']) ? $config['paths'] : [];
+        foreach ($allPaths as $namespace => $paths) {
+            $namespace = is_numeric($namespace) ? null : $namespace;
+            $namespace = $namespace ?: TwigFilesystem::MAIN_NAMESPACE;
+            foreach ((array) $paths as $path) {
+                $loader->addPath($path, $namespace);
+            }
+        }
+
+        // Inject environment
+        return $environment;
+    }
+
+    /**
+     * Inject extensions into the TwigEnvironment instance.
+     *
+     * @param TwigEnvironment    $environment
+     * @param ContainerInterface $container
+     * @param array              $extensions
+     *
+     * @throws Exception\InvalidExtensionException
+     */
+    private function injectExtensions(TwigEnvironment $environment, ContainerInterface $container, array $extensions)
+    {
+        foreach ($extensions as $extension) {
+            // Load the extension from the container
+            if (is_string($extension) && $container->has($extension)) {
+                $extension = $container->get($extension);
+            }
+
+            if (!$extension instanceof TwigExtensionInterface) {
+                throw new Exception\InvalidExtensionException(sprintf(
+                    'Twig extension must be an instance of Twig_ExtensionInterface; "%s" given,',
+                    is_object($extension) ? get_class($extension) : gettype($extension)
+                ));
+            }
+
+            if ($environment->hasExtension($extension->getName())) {
+                continue;
+            }
+
+            $environment->addExtension($extension);
+        }
+    }
+
+    /**
+     * Merge expressive templating config with twig config.
+     *
+     * Pulls the `templates` and `twig` top-level keys from the configuration,
+     * if present, and then returns the merged result, with those from the twig
+     * array having precedence.
+     *
+     * @param array|ArrayObject $config
+     *
+     * @return array
+     * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
+     *     $config is received.
+     */
+    private function mergeConfig($config)
+    {
+        $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
+
+        if (!is_array($config)) {
+            throw new Exception\InvalidConfigException(sprintf(
+                'config service MUST be an array or ArrayObject; received %s',
+                is_object($config) ? get_class($config) : gettype($config)
+            ));
+        }
+
+        $expressiveConfig = (isset($config['templates']) && is_array($config['templates']))
+            ? $config['templates']
+            : [];
+        $twigConfig       = (isset($config['twig']) && is_array($config['twig']))
+            ? $config['twig']
+            : [];
+
+        return array_replace_recursive($expressiveConfig, $twigConfig);
+    }
+}

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -52,7 +52,7 @@ class TwigEnvironmentFactory
     /**
      * @param ContainerInterface $container
      *
-     * @return TwigRenderer
+     * @return TwigEnvironment
      * @throws Exception\InvalidConfigException for invalid config service values.
      */
     public function __invoke(ContainerInterface $container)

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -140,7 +140,7 @@ class TwigEnvironmentFactory
                 ));
             }
 
-            if ($environment->hasExtension($extension->getName())) {
+            if ($environment->hasExtension(get_class($extension))) {
                 continue;
             }
 

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -67,14 +67,6 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
         $this->globals         = $globals;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'zend-expressive';
-    }
-
     public function getGlobals()
     {
         return $this->globals;

--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -44,7 +44,7 @@ class TwigRenderer implements TemplateRendererInterface
      *  Constructor
      *
      * @param TwigEnvironment $template
-     * @param string $suffix
+     * @param string          $suffix
      */
     public function __construct(TwigEnvironment $template = null, $suffix = 'html')
     {

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -9,148 +9,27 @@
 
 namespace Zend\Expressive\Twig;
 
-use ArrayObject;
 use Interop\Container\ContainerInterface;
-use Twig_Environment as TwigEnvironment;
-use Twig_Extension_Debug as TwigExtensionDebug;
-use Twig_ExtensionInterface;
-use Twig_Loader_Filesystem as TwigLoader;
-use Zend\Expressive\Helper\ServerUrlHelper;
-use Zend\Expressive\Helper\UrlHelper;
+use ArrayObject;
 
 /**
  * Create and return a Twig template instance.
- *
- * Optionally uses the service 'config', which should return an array. This
- * factory consumes the following structure:
- *
- * <code>
- * 'debug' => boolean,
- * 'templates' => [
- *     'extension' => 'file extension used by templates; defaults to html.twig',
- *     'paths' => [
- *         // namespace / path pairs
- *         //
- *         // Numeric namespaces imply the default/main namespace. Paths may be
- *         // strings or arrays of string paths to associate with the namespace.
- *     ],
- * ],
- * 'twig' => [
- *     'cache_dir' => 'path to cached templates',
- *     'assets_url' => 'base URL for assets',
- *     'assets_version' => 'base version for assets',
- *     'extensions' => [
- *         // extension service names or instances
- *     ],
- *     'globals' => [
- *         // Global variables passed to twig templates
- *         'ga_tracking' => 'UA-XXXXX-X'
- *     ],
- * ],
- * </code>
- *
- * Note: the various keys in the `twig` configuration key can occur in either
- * that location, or under `templates` (which was the behavior prior to 0.3.0);
- * the two arrays are merged by the factory.
  */
 class TwigRendererFactory
 {
     /**
      * @param ContainerInterface $container
+     *
      * @return TwigRenderer
      * @throws Exception\InvalidConfigException for invalid config service values.
      */
     public function __invoke(ContainerInterface $container)
     {
-        $config   = $container->has('config') ? $container->get('config') : [];
+        $config      = $container->has('config') ? $container->get('config') : [];
+        $config      = $this->mergeConfig($config);
+        $environment = $container->get(TwigEnvironmentFactory::class);
 
-        if (! is_array($config) && ! $config instanceof ArrayObject) {
-            throw new Exception\InvalidConfigException(sprintf(
-                '"config" service must be an array or ArrayObject for the %s to be able to consume it; received %s',
-                __CLASS__,
-                (is_object($config) ? get_class($config) : gettype($config))
-            ));
-        }
-
-        $debug    = array_key_exists('debug', $config) ? (bool) $config['debug'] : false;
-        $config   = $this->mergeConfig($config);
-        $cacheDir = isset($config['cache_dir']) ? $config['cache_dir'] : false;
-
-        // Create the engine instance
-        $loader      = new TwigLoader();
-        $environment = new TwigEnvironment($loader, [
-            'cache'            => $debug ? false : $cacheDir,
-            'debug'            => $debug,
-            'strict_variables' => $debug,
-            'auto_reload'      => $debug
-        ]);
-
-        // Add expressive twig extension
-        if ($container->has(ServerUrlHelper::class) && $container->has(UrlHelper::class)) {
-            $environment->addExtension(new TwigExtension(
-                $container->get(ServerUrlHelper::class),
-                $container->get(UrlHelper::class),
-                isset($config['assets_url']) ? $config['assets_url'] : '',
-                isset($config['assets_version']) ? $config['assets_version'] : '',
-                isset($config['globals']) ? $config['globals'] : []
-            ));
-        }
-
-        // Add debug extension
-        if ($debug) {
-            $environment->addExtension(new TwigExtensionDebug());
-        }
-
-        // Add user defined extensions
-        $extensions = (isset($config['extensions']) && is_array($config['extensions']))
-            ? $config['extensions']
-            : [];
-        $this->injectExtensions($environment, $container, $extensions);
-
-        // Inject environment
-        $twig = new TwigRenderer($environment, isset($config['extension']) ? $config['extension'] : 'html.twig');
-
-        // Add template paths
-        $allPaths = isset($config['paths']) && is_array($config['paths']) ? $config['paths'] : [];
-        foreach ($allPaths as $namespace => $paths) {
-            $namespace = is_numeric($namespace) ? null : $namespace;
-            foreach ((array) $paths as $path) {
-                $twig->addPath($path, $namespace);
-            }
-        }
-
-        return $twig;
-    }
-
-    /**
-     * Inject extensions into the TwigEnvironment instance.
-     *
-     * @param TwigEnvironment $environment
-     * @param ContainerInterface $container
-     * @param array $extensions
-     * @throws Exception\InvalidExtensionException
-     */
-    private function injectExtensions(TwigEnvironment $environment, ContainerInterface $container, array $extensions)
-    {
-        foreach ($extensions as $extension) {
-            // Load the extension from the container
-            if (is_string($extension) && $container->has($extension)) {
-                $extension = $container->get($extension);
-            }
-
-            if (! $extension instanceof Twig_ExtensionInterface) {
-                throw new Exception\InvalidExtensionException(sprintf(
-                    'Twig extension must be an instance of Twig_ExtensionInterface; "%s" given,',
-                    is_object($extension) ? get_class($extension) : gettype($extension)
-                ));
-            }
-
-            if ($environment->hasExtension($extension->getName())) {
-                continue;
-            }
-
-            $environment->addExtension($extension);
-        }
+        return new TwigRenderer($environment, isset($config['extension']) ? $config['extension'] : 'html.twig');
     }
 
     /**
@@ -161,6 +40,7 @@ class TwigRendererFactory
      * array having precedence.
      *
      * @param array|ArrayObject $config
+     *
      * @return array
      * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
      *     $config is received.
@@ -169,7 +49,7 @@ class TwigRendererFactory
     {
         $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
 
-        if (! is_array($config)) {
+        if (!is_array($config)) {
             throw new Exception\InvalidConfigException(sprintf(
                 'config service MUST be an array or ArrayObject; received %s',
                 is_object($config) ? get_class($config) : gettype($config)
@@ -179,7 +59,7 @@ class TwigRendererFactory
         $expressiveConfig = (isset($config['templates']) && is_array($config['templates']))
             ? $config['templates']
             : [];
-        $twigConfig = (isset($config['twig']) && is_array($config['twig']))
+        $twigConfig       = (isset($config['twig']) && is_array($config['twig']))
             ? $config['twig']
             : [];
 

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -11,6 +11,7 @@ namespace Zend\Expressive\Twig;
 
 use ArrayObject;
 use Interop\Container\ContainerInterface;
+use Twig_Environment as TwigEnvironment;
 
 /**
  * Create and return a Twig template instance.
@@ -27,7 +28,7 @@ class TwigRendererFactory
     {
         $config      = $container->has('config') ? $container->get('config') : [];
         $config      = $this->mergeConfig($config);
-        $environment = $container->get(TwigEnvironmentFactory::class);
+        $environment = $container->get(TwigEnvironment::class);
 
         return new TwigRenderer($environment, isset($config['extension']) ? $config['extension'] : 'html.twig');
     }

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -9,8 +9,8 @@
 
 namespace Zend\Expressive\Twig;
 
-use Interop\Container\ContainerInterface;
 use ArrayObject;
+use Interop\Container\ContainerInterface;
 
 /**
  * Create and return a Twig template instance.
@@ -49,7 +49,7 @@ class TwigRendererFactory
     {
         $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
 
-        if (!is_array($config)) {
+        if (! is_array($config)) {
             throw new Exception\InvalidConfigException(sprintf(
                 'config service MUST be an array or ArrayObject; received %s',
                 is_object($config) ? get_class($config) : gettype($config)

--- a/test/TwigEnvironmentFactoryTest.php
+++ b/test/TwigEnvironmentFactoryTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace ZendTest\Expressive\Twig;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Twig_Environment as TwigEnvironment;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Twig\Exception\InvalidConfigException;
+use Zend\Expressive\Twig\Exception\InvalidExtensionException;
+use Zend\Expressive\Twig\TwigEnvironmentFactory;
+use Zend\Expressive\Twig\TwigExtension;
+
+class TwigEnvironmentFactoryTest extends TestCase
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function testCallingFactoryWithNoConfigReturnsTwigEnvironmentInstance()
+    {
+        $this->container->has('config')->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
+        $factory     = new TwigEnvironmentFactory();
+        $environment = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(TwigEnvironment::class, $environment);
+
+        return $environment;
+    }
+
+    public function testUsesDebugConfiguration()
+    {
+        $config = ['debug' => true];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
+        $factory     = new TwigEnvironmentFactory();
+        $environment = $factory($this->container->reveal());
+
+        $this->assertTrue($environment->isDebug());
+        $this->assertFalse($environment->getCache());
+        $this->assertTrue($environment->isStrictVariables());
+        $this->assertTrue($environment->isAutoReload());
+    }
+
+    /**
+     * @depends testCallingFactoryWithNoConfigReturnsTwigEnvironmentInstance
+     */
+    public function testDebugDisabledSetsUpEnvironmentForProduction(TwigEnvironment $environment)
+    {
+        $this->assertFalse($environment->isDebug());
+        $this->assertFalse($environment->isStrictVariables());
+        $this->assertFalse($environment->isAutoReload());
+    }
+
+    public function testCanSpecifyCacheDirectoryViaConfiguration()
+    {
+        $config = ['templates' => ['cache_dir' => __DIR__]];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
+        $factory     = new TwigEnvironmentFactory();
+        $environment = $factory($this->container->reveal());
+
+        $this->assertEquals($config['templates']['cache_dir'], $environment->getCache());
+    }
+
+    public function testAddsTwigExtensionIfRouterIsInContainer()
+    {
+        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
+        $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
+        $this->container->has('config')->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
+        $factory     = new TwigEnvironmentFactory();
+        $environment = $factory($this->container->reveal());
+
+        $this->assertTrue($environment->hasExtension('zend-expressive'));
+    }
+
+    public function testUsesAssetsConfigurationWhenAddingTwigExtension()
+    {
+        $config          = [
+            'templates' => [
+                'assets_url'     => 'http://assets.example.com/',
+                'assets_version' => 'XYZ',
+            ],
+        ];
+        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
+        $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
+        $factory     = new TwigEnvironmentFactory();
+        $environment = $factory($this->container->reveal());
+        $extension   = $environment->getExtension('zend-expressive');
+
+        $this->assertInstanceOf(TwigExtension::class, $extension);
+        $this->assertAttributeEquals($config['templates']['assets_url'], 'assetsUrl', $extension);
+        $this->assertAttributeEquals($config['templates']['assets_version'], 'assetsVersion', $extension);
+        $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $extension);
+        $this->assertAttributeSame($urlHelper, 'urlHelper', $extension);
+    }
+
+    public function invalidExtensions()
+    {
+        return [
+            'null'                  => [null],
+            'true'                  => [true],
+            'false'                 => [false],
+            'zero'                  => [0],
+            'int'                   => [1],
+            'zero-float'            => [0.0],
+            'float'                 => [1.1],
+            'non-service-string'    => ['not-an-extension'],
+            'array'                 => [['not-an-extension']],
+            'non-extensions-object' => [(object) ['extension' => 'not-an-extension']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidExtensions
+     */
+    public function testRaisesExceptionForInvalidExtensions($extension)
+    {
+        $config = [
+            'templates' => [
+            ],
+            'twig'      => [
+                'extensions' => [$extension],
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
+
+        if (is_string($extension)) {
+            $this->container->has($extension)->willReturn(false);
+        }
+
+        $factory = new TwigEnvironmentFactory();
+
+        $this->setExpectedException(InvalidExtensionException::class);
+        $factory($this->container->reveal());
+    }
+
+    public function testConfiguresGlobals()
+    {
+        $config          = [
+            'twig' => [
+                'globals' => [
+                    'ga_tracking' => 'UA-XXXXX-X',
+                    'foo'         => 'bar',
+                ],
+            ],
+        ];
+        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
+        $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
+        $factory     = new TwigEnvironmentFactory();
+        $environment = $factory($this->container->reveal());
+        $extension   = $environment->getExtension('zend-expressive');
+
+        $this->assertInstanceOf(TwigExtension::class, $extension);
+        $this->assertAttributeEquals($config['twig']['globals'], 'globals', $extension);
+        $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $extension);
+        $this->assertAttributeSame($urlHelper, 'urlHelper', $extension);
+    }
+
+    public function invalidConfiguration()
+    {
+        // @codingStandardsIgnoreStart
+        //                        [Config value,                        Type ]
+        return [
+            'true'             => [true, 'boolean'],
+            'false'            => [false, 'boolean'],
+            'zero'             => [0, 'integer'],
+            'int'              => [1, 'integer'],
+            'zero-float'       => [0.0, 'double'],
+            'float'            => [1.1, 'double'],
+            'string'           => ['not-configuration', 'string'],
+            'non-array-object' => [(object) ['not' => 'configuration'], 'stdClass'],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider invalidConfiguration
+     */
+    public function testRaisesExceptionForInvalidConfigService($config, $contains)
+    {
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $factory = new TwigEnvironmentFactory();
+
+        $this->setExpectedException(InvalidConfigException::class, $contains);
+        $factory($this->container->reveal());
+    }
+}

--- a/test/TwigEnvironmentFactoryTest.php
+++ b/test/TwigEnvironmentFactoryTest.php
@@ -88,7 +88,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         $factory     = new TwigEnvironmentFactory();
         $environment = $factory($this->container->reveal());
 
-        $this->assertTrue($environment->hasExtension('zend-expressive'));
+        $this->assertTrue($environment->hasExtension(TwigExtension::class));
     }
 
     public function testUsesAssetsConfigurationWhenAddingTwigExtension()
@@ -109,7 +109,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         $this->container->get(UrlHelper::class)->willReturn($urlHelper);
         $factory     = new TwigEnvironmentFactory();
         $environment = $factory($this->container->reveal());
-        $extension   = $environment->getExtension('zend-expressive');
+        $extension   = $environment->getExtension(TwigExtension::class);
 
         $this->assertInstanceOf(TwigExtension::class, $extension);
         $this->assertAttributeEquals($config['templates']['assets_url'], 'assetsUrl', $extension);
@@ -181,7 +181,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         $this->container->get(UrlHelper::class)->willReturn($urlHelper);
         $factory     = new TwigEnvironmentFactory();
         $environment = $factory($this->container->reveal());
-        $extension   = $environment->getExtension('zend-expressive');
+        $extension   = $environment->getExtension(TwigExtension::class);
 
         $this->assertInstanceOf(TwigExtension::class, $extension);
         $this->assertAttributeEquals($config['twig']['globals'], 'globals', $extension);

--- a/test/TwigExtensionTest.php
+++ b/test/TwigExtensionTest.php
@@ -52,12 +52,6 @@ class TwigExtensionTest extends TestCase
         $this->assertInstanceOf(SimpleFunction::class, $function, $message);
     }
 
-    public function testExtensionIsNamed()
-    {
-        $extension = $this->createExtension('', '');
-        $this->assertEquals('zend-expressive', $extension->getName());
-    }
-
     public function testRegistersTwigFunctions()
     {
         $extension = $this->createExtension('', '');

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -18,6 +18,7 @@ use Zend\Expressive\Template\TemplatePath;
 use Zend\Expressive\Twig\TwigEnvironmentFactory;
 use Zend\Expressive\Twig\TwigRenderer;
 use Zend\Expressive\Twig\TwigRendererFactory;
+use Twig_Environment as TwigEnvironment;
 
 class TwigRendererFactoryTest extends TestCase
 {
@@ -104,8 +105,8 @@ class TwigRendererFactoryTest extends TestCase
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $environment = new TwigEnvironmentFactory();
-        $this->container->has(TwigEnvironmentFactory::class)->willReturn(true);
-        $this->container->get(TwigEnvironmentFactory::class)->willReturn(
+        $this->container->has(TwigEnvironment::class)->willReturn(true);
+        $this->container->get(TwigEnvironment::class)->willReturn(
             $environment($this->container->reveal())
         );
 
@@ -138,8 +139,8 @@ class TwigRendererFactoryTest extends TestCase
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $environment = new TwigEnvironmentFactory();
-        $this->container->has(TwigEnvironmentFactory::class)->willReturn(true);
-        $this->container->get(TwigEnvironmentFactory::class)->willReturn(
+        $this->container->has(TwigEnvironment::class)->willReturn(true);
+        $this->container->get(TwigEnvironment::class)->willReturn(
             $environment($this->container->reveal())
         );
         $factory = new TwigRendererFactory();
@@ -160,8 +161,8 @@ class TwigRendererFactoryTest extends TestCase
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $environment = new TwigEnvironmentFactory();
-        $this->container->has(TwigEnvironmentFactory::class)->willReturn(true);
-        $this->container->get(TwigEnvironmentFactory::class)->willReturn(
+        $this->container->has(TwigEnvironment::class)->willReturn(true);
+        $this->container->get(TwigEnvironment::class)->willReturn(
             $environment($this->container->reveal())
         );
         $factory = new TwigRendererFactory();

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -15,19 +15,15 @@ use ReflectionProperty;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Template\TemplatePath;
-use Zend\Expressive\Twig\Exception\InvalidConfigException;
-use Zend\Expressive\Twig\Exception\InvalidExtensionException;
-use Zend\Expressive\Twig\TwigExtension;
+use Zend\Expressive\Twig\TwigEnvironmentFactory;
 use Zend\Expressive\Twig\TwigRenderer;
 use Zend\Expressive\Twig\TwigRendererFactory;
-use ZendTest\Expressive\Twig\TestAsset\Extension\FooTwigExtension;
-use ZendTest\Expressive\Twig\TestAsset\Extension\BarTwigExtension;
 
 class TwigRendererFactoryTest extends TestCase
 {
     /**
      * @var ContainerInterface
-    */
+     */
     private $container;
 
     public function setUp()
@@ -39,6 +35,7 @@ class TwigRendererFactoryTest extends TestCase
     {
         $r = new ReflectionProperty($twig, 'template');
         $r->setAccessible(true);
+
         return $r->getValue($twig);
     }
 
@@ -46,12 +43,12 @@ class TwigRendererFactoryTest extends TestCase
     {
         return [
             'foo' => __DIR__ . '/TestAsset/bar',
-            1 => __DIR__ . '/TestAsset/one',
+            1     => __DIR__ . '/TestAsset/one',
             'bar' => [
                 __DIR__ . '/TestAsset/baz',
                 __DIR__ . '/TestAsset/bat',
             ],
-            0 => [
+            0     => [
                 __DIR__ . '/TestAsset/two',
                 __DIR__ . '/TestAsset/three',
             ],
@@ -106,9 +103,16 @@ class TwigRendererFactoryTest extends TestCase
         $this->container->has('config')->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
+        $environment = new TwigEnvironmentFactory();
+        $this->container->has(TwigEnvironmentFactory::class)->willReturn(true);
+        $this->container->get(TwigEnvironmentFactory::class)->willReturn(
+            $environment($this->container->reveal())
+        );
+
         $factory = new TwigRendererFactory();
-        $twig = $factory($this->container->reveal());
+        $twig    = $factory($this->container->reveal());
         $this->assertInstanceOf(TwigRenderer::class, $twig);
+
         return $twig;
     }
 
@@ -122,95 +126,6 @@ class TwigRendererFactoryTest extends TestCase
         $this->assertEmpty($paths);
     }
 
-    public function testUsesDebugConfigurationToPrepareEnvironment()
-    {
-        $config = ['debug' => true];
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(ServerUrlHelper::class)->willReturn(false);
-        $this->container->has(UrlHelper::class)->willReturn(false);
-        $factory = new TwigRendererFactory();
-        $twig = $factory($this->container->reveal());
-
-        $environment = $this->fetchTwigEnvironment($twig);
-
-        $this->assertTrue($environment->isDebug());
-        $this->assertFalse($environment->getCache());
-        $this->assertTrue($environment->isStrictVariables());
-        $this->assertTrue($environment->isAutoReload());
-    }
-
-    /**
-     * @depends testCallingFactoryWithNoConfigReturnsTwigInstance
-     */
-    public function testDebugDisabledSetsUpEnvironmentForProduction(TwigRenderer $twig)
-    {
-        $environment = $this->fetchTwigEnvironment($twig);
-
-        $this->assertFalse($environment->isDebug());
-        $this->assertFalse($environment->isStrictVariables());
-        $this->assertFalse($environment->isAutoReload());
-    }
-
-    public function testCanSpecifyCacheDirectoryViaConfiguration()
-    {
-        $config = ['templates' => ['cache_dir' => __DIR__]];
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(ServerUrlHelper::class)->willReturn(false);
-        $this->container->has(UrlHelper::class)->willReturn(false);
-        $factory = new TwigRendererFactory();
-        $twig = $factory($this->container->reveal());
-
-        $environment = $this->fetchTwigEnvironment($twig);
-        $this->assertEquals($config['templates']['cache_dir'], $environment->getCache());
-    }
-
-    public function testAddsTwigExtensionIfRouterIsInContainer()
-    {
-        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
-        $urlHelper = $this->prophesize(UrlHelper::class)->reveal();
-        $this->container->has('config')->willReturn(false);
-        $this->container->has(ServerUrlHelper::class)->willReturn(true);
-        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
-        $this->container->has(UrlHelper::class)->willReturn(true);
-        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
-
-        $factory = new TwigRendererFactory();
-        $twig = $factory($this->container->reveal());
-
-        $environment = $this->fetchTwigEnvironment($twig);
-        $this->assertTrue($environment->hasExtension('zend-expressive'));
-    }
-
-    public function testUsesAssetsConfigurationWhenAddingTwigExtension()
-    {
-        $config = [
-            'templates' => [
-                'assets_url'     => 'http://assets.example.com/',
-                'assets_version' => 'XYZ',
-            ],
-        ];
-        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
-        $urlHelper = $this->prophesize(UrlHelper::class)->reveal();
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(ServerUrlHelper::class)->willReturn(true);
-        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
-        $this->container->has(UrlHelper::class)->willReturn(true);
-        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
-        $factory = new TwigRendererFactory();
-        $twig = $factory($this->container->reveal());
-
-        $environment = $this->fetchTwigEnvironment($twig);
-        $extension = $environment->getExtension('zend-expressive');
-        $this->assertInstanceOf(TwigExtension::class, $extension);
-        $this->assertAttributeEquals($config['templates']['assets_url'], 'assetsUrl', $extension);
-        $this->assertAttributeEquals($config['templates']['assets_version'], 'assetsVersion', $extension);
-        $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $extension);
-        $this->assertAttributeSame($urlHelper, 'urlHelper', $extension);
-    }
-
     public function testConfiguresTemplateSuffix()
     {
         $config = [
@@ -222,8 +137,13 @@ class TwigRendererFactoryTest extends TestCase
         $this->container->get('config')->willReturn($config);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
+        $environment = new TwigEnvironmentFactory();
+        $this->container->has(TwigEnvironmentFactory::class)->willReturn(true);
+        $this->container->get(TwigEnvironmentFactory::class)->willReturn(
+            $environment($this->container->reveal())
+        );
         $factory = new TwigRendererFactory();
-        $twig = $factory($this->container->reveal());
+        $twig    = $factory($this->container->reveal());
 
         $this->assertAttributeSame($config['templates']['extension'], 'suffix', $twig);
     }
@@ -239,8 +159,13 @@ class TwigRendererFactoryTest extends TestCase
         $this->container->get('config')->willReturn($config);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
+        $environment = new TwigEnvironmentFactory();
+        $this->container->has(TwigEnvironmentFactory::class)->willReturn(true);
+        $this->container->get(TwigEnvironmentFactory::class)->willReturn(
+            $environment($this->container->reveal())
+        );
         $factory = new TwigRendererFactory();
-        $twig = $factory($this->container->reveal());
+        $twig    = $factory($this->container->reveal());
 
         $paths = $twig->getPaths();
         $this->assertPathsHasNamespace('foo', $paths);
@@ -257,135 +182,5 @@ class TwigRendererFactoryTest extends TestCase
         $this->assertPathNamespaceContains(__DIR__ . '/TestAsset/one', null, $paths);
         $this->assertPathNamespaceContains(__DIR__ . '/TestAsset/two', null, $paths);
         $this->assertPathNamespaceContains(__DIR__ . '/TestAsset/three', null, $paths);
-    }
-
-    public function testInjectsCustomExtensionsIntoTwigEnvironment()
-    {
-        $config = [
-            'templates' => [
-            ],
-            'twig' => [
-                'extensions' => [
-                    new FooTwigExtension(),
-                    BarTwigExtension::class,
-                ],
-            ],
-        ];
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(ServerUrlHelper::class)->willReturn(false);
-        $this->container->has(UrlHelper::class)->willReturn(false);
-        $this->container->has(BarTwigExtension::class)->willReturn(true);
-        $this->container->get(BarTwigExtension::class)->willReturn(new BarTwigExtension());
-        $factory = new TwigRendererFactory();
-        $view = $factory($this->container->reveal());
-        $this->assertInstanceOf(TwigRenderer::class, $view);
-        $environment = $this->fetchTwigEnvironment($view);
-        $this->assertTrue($environment->hasExtension('foo-twig-extension'));
-        $this->assertInstanceOf(FooTwigExtension::class, $environment->getExtension('foo-twig-extension'));
-        $this->assertTrue($environment->hasExtension('bar-twig-extension'));
-        $this->assertInstanceOf(BarTwigExtension::class, $environment->getExtension('bar-twig-extension'));
-    }
-
-    public function invalidExtensions()
-    {
-        return [
-            'null'                  => [null],
-            'true'                  => [true],
-            'false'                 => [false],
-            'zero'                  => [0],
-            'int'                   => [1],
-            'zero-float'            => [0.0],
-            'float'                 => [1.1],
-            'non-service-string'    => ['not-an-extension'],
-            'array'                 => [['not-an-extension']],
-            'non-extensions-object' => [(object) ['extension' => 'not-an-extension']],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidExtensions
-     */
-    public function testRaisesExceptionForInvalidExtensions($extension)
-    {
-        $config = [
-            'templates' => [
-            ],
-            'twig' => [
-                'extensions' => [ $extension ],
-            ],
-        ];
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(ServerUrlHelper::class)->willReturn(false);
-        $this->container->has(UrlHelper::class)->willReturn(false);
-
-        if (is_string($extension)) {
-            $this->container->has($extension)->willReturn(false);
-        }
-
-        $factory = new TwigRendererFactory();
-
-        $this->setExpectedException(InvalidExtensionException::class);
-        $factory($this->container->reveal());
-    }
-
-    public function testConfiguresGlobals()
-    {
-        $config = [
-            'twig' => [
-                'globals' => [
-                    'ga_tracking' => 'UA-XXXXX-X',
-                    'foo' => 'bar',
-                ],
-            ],
-        ];
-        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
-        $urlHelper = $this->prophesize(UrlHelper::class)->reveal();
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(ServerUrlHelper::class)->willReturn(true);
-        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
-        $this->container->has(UrlHelper::class)->willReturn(true);
-        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
-        $factory = new TwigRendererFactory();
-        $twig = $factory($this->container->reveal());
-
-        $environment = $this->fetchTwigEnvironment($twig);
-        $extension = $environment->getExtension('zend-expressive');
-        $this->assertInstanceOf(TwigExtension::class, $extension);
-        $this->assertAttributeEquals($config['twig']['globals'], 'globals', $extension);
-        $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $extension);
-        $this->assertAttributeSame($urlHelper, 'urlHelper', $extension);
-    }
-
-    public function invalidConfiguration()
-    {
-        // @codingStandardsIgnoreStart
-        //                        [Config value,                        Type ]
-        return [
-            'true'             => [true,                                'boolean'],
-            'false'            => [false,                               'boolean'],
-            'zero'             => [0,                                   'integer'],
-            'int'              => [1,                                   'integer'],
-            'zero-float'       => [0.0,                                 'double'],
-            'float'            => [1.1,                                 'double'],
-            'string'           => ['not-configuration',                 'string'],
-            'non-array-object' => [(object) ['not' => 'configuration'], 'stdClass'],
-        ];
-        // @codingStandardsIgnoreEnd
-    }
-
-    /**
-     * @dataProvider invalidConfiguration
-     */
-    public function testRaisesExceptionForInvalidConfigService($config, $contains)
-    {
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-
-        $factory = new TwigRendererFactory();
-        $this->setExpectedException(InvalidConfigException::class, $contains);
-        $factory($this->container->reveal());
     }
 }


### PR DESCRIPTION
This PR removes the Twig_ExtensionInterface::getName() and increases the minimum required Twig version to 1.26.

I've made this PR on top of zendframework/zend-expressive-twigrenderer#15 since a lot of changes have been made to the tests in there. This should make it easier to merge (I hope).

As of Twig 1.26, the Twig_ExtensionInterface::getName() method is deprecated and it is not used internally anymore. It will be removed in Twig 2.0. To prevent possible issues with older versions, the minimum required Twig version is increased.