### PR TITLE
Including support to inject Twig Runtime Loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ container.
     'extensions' => [
         // extension service names or instances
     ],
+    'runtime_loaders' => [
+        // runtime loaders names or instances   
+    ],
     'globals' => [
         // Global variables passed to twig templates
         'ga_tracking' => 'UA-XXXXX-X'

--- a/src/Exception/InvalidRuntimeLoaderException.php
+++ b/src/Exception/InvalidRuntimeLoaderException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Twig\Exception;
+
+use DomainException;
+use Interop\Container\Exception\ContainerException;
+
+class InvalidRuntimeLoaderException extends DomainException implements
+    ContainerException,
+    ExceptionInterface
+{
+}


### PR DESCRIPTION
Class `Zend\Expressive\Twig\TwigRendererFactory` modified to read the config key `[twig][runtime_loaders]` and inject the objects registered in it into the RuntimeLoaders list in the `Twig_Environment`.

