### PR TITLE
Fix zend-expressive-router constrain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "container-interop/container-interop": "^1.1",
         "twig/twig": "^1.26",
         "zendframework/zend-expressive-helpers": "^1.1 || ^2.0 || ^3.0",
-        "zendframework/zend-expressive-router": "^1.3.2 || ^3.0",
+        "zendframework/zend-expressive-router": "^1.3.2 || ^2.0",
         "zendframework/zend-expressive-template": "^1.0.4"
     },
     "require-dev": {


### PR DESCRIPTION
zend-expressive-router is currently at version 2.0, not 3.0

Thanx @remicollet for reporting [this](https://github.com/zendframework/zend-expressive-twigrenderer/commit/16def0188c56cd23a25dc3450ac25972187a6110#commitcomment-20447349).