### PR TITLE
Support Twig 2.1

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_clover: clover.xml
+json_path: coveralls-upload.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 /test export-ignore
-/vendor export-ignore
+.coveralls.yml
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
-phpunit.xml.dist export-ignore
 phpcs.xml export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 vendor/
+phpunit.xml
+clover.xml
+coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="satooshi/php-coveralls"
+    - LEGACY_DEPS="phpunit/phpunit"
 
 matrix:
   include:
@@ -61,10 +62,11 @@ before_install:
   - travis_retry composer self-update
 
 install:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - travis_retry composer install $COMPOSER_ARGS
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - composer show
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="satooshi/php-coveralls"
-    - LEGACY_DEPS="phpunit/phpunit"
+    - LEGACY_DEPS="phpunit/phpunit twig/twig"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,15 @@ language: php
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.local
     - vendor
 
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"
+    - COVERAGE_DEPS="satooshi/php-coveralls"
 
 matrix:
-  fast_finish: false
   include:
     - php: 5.6
       env:
@@ -20,7 +21,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - CS_CHECK=true
+        - TEST_COVERAGE=true
     - php: 5.6
       env:
         - DEPS=latest
@@ -30,6 +31,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
+        - CS_CHECK=true
     - php: 7
       env:
         - DEPS=latest
@@ -55,18 +57,23 @@ matrix:
     - php: hhvm
 
 before_install:
+  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - travis_retry composer self-update
 
 install:
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
-  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - travis_retry composer install $COMPOSER_ARGS
   - composer show
 
 script:
-  - composer test
-  - if [[ $CS_CHECK == 'true' ]]; then composer cs ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
+  - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer license-check ; fi
+
+after_script:
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,18 +41,17 @@ To run tests:
 - Clone the repository:
 
   ```console
-  $ git clone git@github.com:zendframework/zend-expressive-twigrenderer.git
+  $ git clone git://github.com/zendframework/zend-expressive-twigrenderer.git
   $ cd zend-expressive-twigrenderer
   ```
 
 - Install dependencies via composer:
 
   ```console
-  $ curl -sS https://getcomposer.org/installer | php --
-  $ ./composer.phar install
+  $ composer install
   ```
 
-  If you don't have `curl` installed, you can also download `composer.phar` from https://getcomposer.org/
+  If you don't have `composer` installed, please download it from https://getcomposer.org/download/
 
 - Run the tests using the "test" command shipped in the `composer.json`:
 
@@ -75,11 +74,10 @@ section on running tests.
 To run CS checks only:
 
 ```console
-$ composer cs
+$ composer cs-check
 ```
 
 To attempt to automatically fix common CS issues:
-
 
 ```console
 $ composer cs-fix
@@ -88,18 +86,30 @@ $ composer cs-fix
 If the above fixes any CS issues, please re-run the tests to ensure
 they pass, and make sure you add and commit the changes after verification.
 
+## Running License Checks
+
+File-level docblocks should follow the format demonstrated in `.docheader`. To
+check for conformity, use:
+
+```console
+$ composer license-check
+```
+
+This will flag files that are incorrect, which you can then update. Re-run the
+tool to verify your changes.
+
 ## Recommended Workflow for Contributions
 
 Your first step is to establish a public repository from which we can
 pull your work into the master repository. We recommend using
 [GitHub](https://github.com), as that is where the component is already hosted.
 
-1. Setup a [GitHub account](http://github.com/), if you haven't yet
-2. Fork the repository (http://github.com/zendframework/zend-expressive-twigrenderer)
+1. Setup a [GitHub account](https://github.com/), if you haven't yet
+2. Fork the repository (https://github.com/zendframework/zend-expressive-twigrenderer)
 3. Clone the canonical repository locally and enter it.
 
    ```console
-   $ git clone git://github.com:zendframework/zend-expressive-twigrenderer.git
+   $ git clone git://github.com/zendframework/zend-expressive-twigrenderer.git
    $ cd zend-expressive-twigrenderer
    ```
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,12 +1,28 @@
-Copyright (c) 2015, Zend Technologies USA, Inc.
+Copyright (c) 2015-2017, Zend Technologies USA, Inc.
+
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-- Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
 
-- Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-- Neither the name of Zend Technologies USA, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+- Neither the name of Zend Technologies USA, Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -128,5 +128,4 @@ are registered with the container.
 
 ## Documentation
 
-See the [zend-expressive](https://github.com/zendframework/zend-expressive/blob/master/doc/book)
-documentation tree, or browse online at https://docs.zendframework.com/zend-expressive/features/template/twig/.
+See the Expressive [Twig documentation](https://docs.zendframework.com/zend-expressive/features/template/twig/).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Twig Integration for Expressive
 
 [![Build Status](https://secure.travis-ci.org/zendframework/zend-expressive-twigrenderer.svg?branch=master)](https://secure.travis-ci.org/zendframework/zend-expressive-twigrenderer)
+[![Coverage Status](https://coveralls.io/repos/zendframework/zend-expressive-twigrenderer/badge.svg?branch=master)](https://coveralls.io/r/zendframework/zend-expressive-twigrenderer?branch=master)
 
 Provides [Twig](http://twig.sensiolabs.org/) integration for
 [Expressive](https://docs.zendframework.com//zend-expressive/).

--- a/composer.json
+++ b/composer.json
@@ -42,18 +42,20 @@
     },
     "suggest": {
         "mouf/pimple-interop": "^1.0 to use Pimple for dependency injection",
-        "aura/di": "3.0.*@beta to make use of Aura.Di dependency injection container",
-        "zendframework/zend-servicemanager": "^2.5 to use zend-servicemanager for dependency injection"
+        "aura/di": "^3.2 to make use of Aura.Di dependency injection container",
+        "zendframework/zend-servicemanager": "^3.2 to use zend-servicemanager for dependency injection"
     },
     "scripts": {
         "check": [
             "@license-check",
-            "@cs",
+            "@cs-check",
             "@test"
         ],
-        "cs": "phpcs",
-        "cs-fix": "phpcbf",
+        "upload-coverage": "coveralls -v",
+        "cs-check": "phpcs --colors",
+        "cs-fix": "phpcbf --colors",
         "license-check": "docheader check src/ test/",
-        "test": "phpunit"
+        "test": "phpunit --colors=always",
+        "test-coverage": "phpunit --coverage-clover clover.xml"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,16 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "container-interop/container-interop": "^1.1",
-        "twig/twig": "^1.26",
-        "zendframework/zend-expressive-helpers": "^1.1 || ^2.0 || ^3.0",
-        "zendframework/zend-expressive-router": "^1.3.2 || ^2.0",
+        "container-interop/container-interop": "^1.2",
+        "twig/twig": "^1.32",
+        "zendframework/zend-expressive-helpers": "^1.4 || ^2.2 || ^3.0.1",
+        "zendframework/zend-expressive-router": "^1.3.2 || ^2.1",
         "zendframework/zend-expressive-template": "^1.0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0",
-        "zendframework/zend-coding-standard": "~1.0.0",
-        "malukenho/docheader": "^0.1.5"
+        "malukenho/docheader": "^0.1.5",
+        "phpunit/phpunit": "^6.0.7 || ^5.7.14",
+        "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {
       "psr-4": {
@@ -43,7 +43,7 @@
     "suggest": {
         "mouf/pimple-interop": "^1.0 to use Pimple for dependency injection",
         "aura/di": "^3.2 to make use of Aura.Di dependency injection container",
-        "zendframework/zend-servicemanager": "^3.2 to use zend-servicemanager for dependency injection"
+        "zendframework/zend-servicemanager": "^3.3 to use zend-servicemanager for dependency injection"
     },
     "scripts": {
         "check": [

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "container-interop/container-interop": "^1.2",
-        "twig/twig": "^1.32",
+        "twig/twig": "^1.32 || ^2.1",
         "zendframework/zend-expressive-helpers": "^1.4 || ^2.2 || ^3.0.1",
         "zendframework/zend-expressive-router": "^1.3.2 || ^2.1",
         "zendframework/zend-expressive-template": "^1.0.4"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "zendframework/zend-expressive-template": "^1.0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^5.7 || ^6.0",
         "zendframework/zend-coding-standard": "~1.0.0",
         "malukenho/docheader": "^0.1.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "47181052ab938092c806b02ecf526cab",
+    "content-hash": "1fc05766b4dec04162bbf5f4a8bb8f10",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8cb0e8c16f787cc6e0a048a942e0eaad",
+    "content-hash": "0a7d75461e36d2bce31e89531c8914ed",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d7736193b863afdbd2fc61176f44d411",
-    "content-hash": "7b19f967d71a8ff4c463638ff67968ed",
+    "content-hash": "47181052ab938092c806b02ecf526cab",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -32,20 +31,20 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30 15:22:37"
+            "time": "2014-12-30T15:22:37+00:00"
         },
         {
             "name": "fig/http-message-util",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message-util.git",
-                "reference": "70899e53776d4d65fec9f90f0f88ba6c4d0f7b88"
+                "reference": "2794f0e6a2566c9cd6a9a521a729da8963a52ca4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/70899e53776d4d65fec9f90f0f88ba6c4d0f7b88",
-                "reference": "70899e53776d4d65fec9f90f0f88ba6c4d0f7b88",
+                "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/2794f0e6a2566c9cd6a9a521a729da8963a52ca4",
+                "reference": "2794f0e6a2566c9cd6a9a521a729da8963a52ca4",
                 "shasum": ""
             },
             "require": {
@@ -82,7 +81,59 @@
                 "request",
                 "response"
             ],
-            "time": "2016-09-19 14:52:54"
+            "time": "2017-02-06T19:24:13+00:00"
+        },
+        {
+            "name": "http-interop/http-middleware",
+            "version": "0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-middleware.git",
+                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Http\\ServerMiddleware\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "factory",
+                "http",
+                "middleware",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2017-01-14T15:23:42+00:00"
         },
         {
             "name": "psr/http-message",
@@ -132,7 +183,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "twig/twig",
@@ -193,29 +244,30 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-01-11 19:36:15"
+            "time": "2017-01-11T19:36:15+00:00"
         },
         {
             "name": "zendframework/zend-expressive-helpers",
-            "version": "2.2.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-helpers.git",
-                "reference": "b60666a7a2928bda15fceadcf15116c7df03b5e3"
+                "reference": "51f4248aa837b9e253579db341c1d454e3e34144"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-helpers/zipball/b60666a7a2928bda15fceadcf15116c7df03b5e3",
-                "reference": "b60666a7a2928bda15fceadcf15116c7df03b5e3",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-helpers/zipball/51f4248aa837b9e253579db341c1d454e3e34144",
+                "reference": "51f4248aa837b9e253579db341c1d454e3e34144",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.1",
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0",
-                "zendframework/zend-expressive-router": "^1.1"
+                "zendframework/zend-expressive-router": "^2.0.0"
             },
             "require-dev": {
+                "malukenho/docheader": "^0.1.5",
                 "mockery/mockery": "^0.9.5",
                 "phpunit/phpunit": "^4.7",
                 "zendframework/zend-coding-standard": "~1.0.0",
@@ -229,9 +281,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev",
-                    "dev-dev-3.0.0": "3.0.0-dev"
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
                 }
             },
             "autoload": {
@@ -251,24 +302,25 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-12-24 05:02:55"
+            "time": "2017-01-12T17:59:13+00:00"
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "1.3.2",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "50c9e4dff0cf65d9937c56b597c530e1bf5f8ef0"
+                "reference": "88d711aee740ac8fbd684472469e16b85435cc79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/50c9e4dff0cf65d9937c56b597c530e1bf5f8ef0",
-                "reference": "50c9e4dff0cf65d9937c56b597c530e1bf5f8ef0",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/88d711aee740ac8fbd684472469e16b85435cc79",
+                "reference": "88d711aee740ac8fbd684472469e16b85435cc79",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1",
+                "http-interop/http-middleware": "^0.4.1",
                 "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0"
             },
@@ -285,8 +337,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev",
-                    "dev-develop": "2.0.x-dev"
+                    "dev-master": "2.1-dev",
+                    "dev-develop": "2.2-dev"
                 }
             },
             "autoload": {
@@ -306,7 +358,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-12-14 13:49:15"
+            "time": "2017-01-24T22:28:12+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -355,7 +407,7 @@
                 "expressive",
                 "template"
             ],
-            "time": "2017-01-11 18:42:34"
+            "time": "2017-01-11T18:42:34+00:00"
         }
     ],
     "packages-dev": [
@@ -411,7 +463,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "malukenho/docheader",
@@ -461,20 +513,20 @@
                 "code standard",
                 "license"
             ],
-            "time": "2016-11-17 16:46:05"
+            "time": "2016-11-17T16:46:05+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.5.5",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108"
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/399c1f9781e222f6eb6cc238796f5200d1b7f108",
-                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
                 "shasum": ""
             },
             "require": {
@@ -503,7 +555,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2016-10-31 17:19:45"
+            "time": "2017-01-26T22:05:40+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -557,7 +609,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -602,7 +654,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -649,7 +701,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -712,20 +764,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c14196e64a78570034afd0b7a9f3757ba71c2a0a"
+                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c14196e64a78570034afd0b7a9f3757ba71c2a0a",
-                "reference": "c14196e64a78570034afd0b7a9f3757ba71c2a0a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
+                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
                 "shasum": ""
             },
             "require": {
@@ -775,7 +827,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-20 15:22:42"
+            "time": "2017-01-20T15:06:43+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -822,7 +874,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -863,7 +915,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -907,7 +959,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -956,20 +1008,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2016-11-15T14:06:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.5",
+            "version": "5.7.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "50fd2be8f3e23e91da825f36f08e5f9633076ffe"
+                "reference": "a6ad2472daba76b0689042b7709f86d4f06bcaab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/50fd2be8f3e23e91da825f36f08e5f9633076ffe",
-                "reference": "50fd2be8f3e23e91da825f36f08e5f9633076ffe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6ad2472daba76b0689042b7709f86d4f06bcaab",
+                "reference": "a6ad2472daba76b0689042b7709f86d4f06bcaab",
                 "shasum": ""
             },
             "require": {
@@ -981,16 +1033,16 @@
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.3",
+                "phpunit/php-code-coverage": "^4.0.4",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "~1.2.2",
+                "sebastian/comparator": "^1.2.4",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "^1.3.4 || ^2.0",
                 "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.0 || ^2.0",
+                "sebastian/global-state": "^1.1",
                 "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
                 "sebastian/version": "~1.0|~2.0",
@@ -1038,7 +1090,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-28 07:18:51"
+            "time": "2017-02-05T15:31:31+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1097,7 +1149,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-12-08 20:27:08"
+            "time": "2016-12-08T20:27:08+00:00"
         },
         {
             "name": "psr/log",
@@ -1144,7 +1196,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1189,20 +1241,20 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
+            "time": "2016-02-13T06:45:14+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.2",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
@@ -1253,7 +1305,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19 09:18:40"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1305,7 +1357,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1355,7 +1407,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26 07:53:53"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1422,7 +1474,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19 08:54:04"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1473,7 +1525,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1519,7 +1571,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-11-19 07:35:10"
+            "time": "2016-11-19T07:35:10+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1572,7 +1624,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19 07:33:16"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1614,7 +1666,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1657,20 +1709,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.7.1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f"
+                "reference": "86dd55a522238211f9f3631e3361703578941d9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9b324f3a1132459a7274a0ace2e1b766ba80930f",
-                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/86dd55a522238211f9f3631e3361703578941d9a",
+                "reference": "86dd55a522238211f9f3631e3361703578941d9a",
                 "shasum": ""
             },
             "require": {
@@ -1735,20 +1787,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-11-30 04:02:31"
+            "time": "2017-02-02T03:30:00+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.2.1",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d12aa9ca20f4db83ec58410978dab6afcb9d6aaa"
+                "reference": "7a8405a9fc175f87fed8a3c40856b0d866d61936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d12aa9ca20f4db83ec58410978dab6afcb9d6aaa",
-                "reference": "d12aa9ca20f4db83ec58410978dab6afcb9d6aaa",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7a8405a9fc175f87fed8a3c40856b0d866d61936",
+                "reference": "7a8405a9fc175f87fed8a3c40856b0d866d61936",
                 "shasum": ""
             },
             "require": {
@@ -1798,20 +1850,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-11 14:34:22"
+            "time": "2017-02-06T12:04:21+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.2.1",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "9f923e68d524a3095c5a2ae5fc7220c7cbc12231"
+                "reference": "b4d9818f127c60ce21ed62c395da7df868dc8477"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/9f923e68d524a3095c5a2ae5fc7220c7cbc12231",
-                "reference": "9f923e68d524a3095c5a2ae5fc7220c7cbc12231",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/b4d9818f127c60ce21ed62c395da7df868dc8477",
+                "reference": "b4d9818f127c60ce21ed62c395da7df868dc8477",
                 "shasum": ""
             },
             "require": {
@@ -1855,20 +1907,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-16 22:18:16"
+            "time": "2017-01-28T02:37:08+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.2.1",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b"
+                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b",
-                "reference": "a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8c71141cae8e2957946b403cc71a67213c0380d6",
+                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6",
                 "shasum": ""
             },
             "require": {
@@ -1904,7 +1956,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-13 09:39:43"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1963,20 +2015,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.1",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a7095af4b97a0955f85c8989106c249fa649011f"
+                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7095af4b97a0955f85c8989106c249fa649011f",
-                "reference": "a7095af4b97a0955f85c8989106c249fa649011f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e1718c6bf57e1efbb8793ada951584b2ab27775b",
+                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b",
                 "shasum": ""
             },
             "require": {
@@ -2018,7 +2070,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-10 10:07:06"
+            "time": "2017-01-21T17:06:35+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2068,7 +2120,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -2097,7 +2149,7 @@
                 "Coding Standard",
                 "zf"
             ],
-            "time": "2016-11-09 21:30:43"
+            "time": "2016-11-09T21:30:43+00:00"
         }
     ],
     "aliases": [],
@@ -2106,7 +2158,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.5 || ^7.0"
+        "php": "^5.6 || ^7.0"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fc05766b4dec04162bbf5f4a8bb8f10",
+    "content-hash": "8cb0e8c16f787cc6e0a048a942e0eaad",
     "packages": [
         {
             "name": "container-interop/container-interop",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
                 "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
             },
             "type": "library",
             "autoload": {
@@ -31,20 +34,21 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30T15:22:37+00:00"
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "fig/http-message-util",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message-util.git",
-                "reference": "2794f0e6a2566c9cd6a9a521a729da8963a52ca4"
+                "reference": "20b2c280cb6914b7b83089720df44e490f4b42f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/2794f0e6a2566c9cd6a9a521a729da8963a52ca4",
-                "reference": "2794f0e6a2566c9cd6a9a521a729da8963a52ca4",
+                "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/20b2c280cb6914b7b83089720df44e490f4b42f0",
+                "reference": "20b2c280cb6914b7b83089720df44e490f4b42f0",
                 "shasum": ""
             },
             "require": {
@@ -81,7 +85,7 @@
                 "request",
                 "response"
             ],
-            "time": "2017-02-06T19:24:13+00:00"
+            "time": "2017-02-09T16:10:21+00:00"
         },
         {
             "name": "http-interop/http-middleware",
@@ -136,6 +140,55 @@
             "time": "2017-01-14T15:23:42+00:00"
         },
         {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -187,29 +240,30 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "ddc9e3e20ee9c0b6908f401ac8353635b750eca7"
+                "reference": "9935b662e24d6e634da88901ab534cc12e8c728f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ddc9e3e20ee9c0b6908f401ac8353635b750eca7",
-                "reference": "ddc9e3e20ee9c0b6908f401ac8353635b750eca7",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9935b662e24d6e634da88901ab534cc12e8c728f",
+                "reference": "9935b662e24d6e634da88901ab534cc12e8c728f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.2.7"
             },
             "require-dev": {
+                "psr/container": "^1.0",
                 "symfony/debug": "~2.7",
                 "symfony/phpunit-bridge": "~3.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.31-dev"
+                    "dev-master": "1.32-dev"
                 }
             },
             "autoload": {
@@ -244,7 +298,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-01-11T19:36:15+00:00"
+            "time": "2017-02-27T00:07:03+00:00"
         },
         {
             "name": "zendframework/zend-expressive-helpers",
@@ -768,35 +822,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.5",
+            "version": "4.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971"
+                "reference": "09e2277d14ea467e5a984010f501343ef29ffc69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
-                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/09e2277d14ea467e5a984010f501343ef29ffc69",
+                "reference": "09e2277d14ea467e5a984010f501343ef29ffc69",
                 "shasum": ""
             },
             "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
                 "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "^1.4.2",
-                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
                 "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "~1.0|~2.0"
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "^5.4"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.4.0",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
@@ -827,7 +881,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-01-20T15:06:43+00:00"
+            "time": "2017-03-01T09:12:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -919,25 +973,30 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -959,20 +1018,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12T18:03:57+00:00"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.9",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
@@ -1008,20 +1067,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15T14:06:22+00:00"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.11",
+            "version": "5.7.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a6ad2472daba76b0689042b7709f86d4f06bcaab"
+                "reference": "4906b8faf23e42612182fd212eb6f4c0f2954b57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6ad2472daba76b0689042b7709f86d4f06bcaab",
-                "reference": "a6ad2472daba76b0689042b7709f86d4f06bcaab",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4906b8faf23e42612182fd212eb6f4c0f2954b57",
+                "reference": "4906b8faf23e42612182fd212eb6f4c0f2954b57",
                 "shasum": ""
             },
             "require": {
@@ -1045,7 +1104,7 @@
                 "sebastian/global-state": "^1.1",
                 "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0|~2.0",
+                "sebastian/version": "~1.0.3|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
             "conflict": {
@@ -1090,7 +1149,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-05T15:31:31+00:00"
+            "time": "2017-02-19T07:22:16+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1529,16 +1588,16 @@
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35"
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
-                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
                 "shasum": ""
             },
             "require": {
@@ -1571,7 +1630,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-11-19T07:35:10+00:00"
+            "time": "2017-02-18T15:18:39+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1713,16 +1772,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "86dd55a522238211f9f3631e3361703578941d9a"
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/86dd55a522238211f9f3631e3361703578941d9a",
-                "reference": "86dd55a522238211f9f3631e3361703578941d9a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
                 "shasum": ""
             },
             "require": {
@@ -1787,20 +1846,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-02-02T03:30:00+00:00"
+            "time": "2017-03-01T22:17:45+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.2.3",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7a8405a9fc175f87fed8a3c40856b0d866d61936"
+                "reference": "0e5e6899f82230fcb1153bcaf0e106ffaa44b870"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7a8405a9fc175f87fed8a3c40856b0d866d61936",
-                "reference": "7a8405a9fc175f87fed8a3c40856b0d866d61936",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0e5e6899f82230fcb1153bcaf0e106ffaa44b870",
+                "reference": "0e5e6899f82230fcb1153bcaf0e106ffaa44b870",
                 "shasum": ""
             },
             "require": {
@@ -1850,20 +1909,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-06T12:04:21+00:00"
+            "time": "2017-02-16T14:07:22+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.2.3",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "b4d9818f127c60ce21ed62c395da7df868dc8477"
+                "reference": "9b98854cb45bc59d100b7d4cc4cf9e05f21026b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/b4d9818f127c60ce21ed62c395da7df868dc8477",
-                "reference": "b4d9818f127c60ce21ed62c395da7df868dc8477",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/9b98854cb45bc59d100b7d4cc4cf9e05f21026b9",
+                "reference": "9b98854cb45bc59d100b7d4cc4cf9e05f21026b9",
                 "shasum": ""
             },
             "require": {
@@ -1907,11 +1966,11 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-28T02:37:08+00:00"
+            "time": "2017-02-16T16:34:18+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.2.3",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -2019,16 +2078,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.3",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b"
+                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e1718c6bf57e1efbb8793ada951584b2ab27775b",
-                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
+                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
                 "shasum": ""
             },
             "require": {
@@ -2070,7 +2129,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21T17:06:35+00:00"
+            "time": "2017-02-16T22:46:52+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -11,6 +11,7 @@ use ArrayObject;
 use DateTimeZone;
 use Interop\Container\ContainerInterface;
 use Twig_Environment as TwigEnvironment;
+use Twig_Extension_Core as TwigExtensionCore;
 use Twig_Extension_Debug as TwigExtensionDebug;
 use Twig_ExtensionInterface as TwigExtensionInterface;
 use Twig_Loader_Filesystem as TwigLoader;
@@ -99,7 +100,7 @@ class TwigEnvironmentFactory
             } catch (\Exception $e) {
                 throw new Exception\InvalidConfigException(sprintf('Unknown or invalid timezone: "%s"', $timezone));
             }
-            $environment->getExtension('core')->setTimezone($timezone);
+            $environment->getExtension(TwigExtensionCore::class)->setTimezone($timezone);
         }
 
         // Add expressive twig extension

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -150,6 +150,7 @@ class TwigEnvironmentFactory
      * @param TwigEnvironment $environment
      * @param ContainerInterface $container
      * @param array $extensions
+     * @return void
      * @throws Exception\InvalidExtensionException if any extension provided or
      *     retrieved does not implement TwigExtensionInterface.
      */
@@ -199,7 +200,8 @@ class TwigEnvironmentFactory
      *
      * @param TwigEnvironment $environment
      * @param ContainerInterface $container
-     * @param array $runtimeLoaders
+     * @param array $runtimes
+     * @return void
      * @throws Exception\InvalidRuntimeLoaderException if a given runtime loader
      *     or the service it represents is not a TwigRuntimeLoaderInterface instance.
      */

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -170,10 +170,10 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      */
     public function renderAssetUrl($path, $version = null)
     {
-        $assetsVersion = ($version !== null && $version !== '') ? $version : $this->assetsVersion;
+        $assetsVersion = $version !== null && $version !== '' ? $version : $this->assetsVersion;
 
         // One more time, in case $this->assetsVersion was null or an empty string
-        $assetsVersion = ($assetsVersion !== null && $assetsVersion !== '') ? '?v=' . $assetsVersion : '';
+        $assetsVersion = $assetsVersion !== null && $assetsVersion !== '' ? '?v=' . $assetsVersion : '';
 
         return $this->assetsUrl . $path . $assetsVersion;
     }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -65,6 +65,9 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
         $this->globals         = $globals;
     }
 
+    /**
+     * @return array
+     */
     public function getGlobals()
     {
         return $this->globals;
@@ -99,7 +102,6 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * @param array       $options      Can have the following keys:
      *                                  - reuse_result_params (bool): indicates if the current
      *                                  RouteResult parameters will be used, defaults to true
-     *
      * @return string
      */
     public function renderUri(
@@ -128,7 +130,6 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * @param array       $options      Can have the following keys:
      *                                  - reuse_result_params (bool): indicates if the current
      *                                  RouteResult parameters will be used, defaults to true
-     *
      * @return string
      */
     public function renderUrl(
@@ -149,8 +150,7 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Usage: {{ absolute_url('path/to/something') }}
      * Generates: http://example.com/path/to/something
      *
-     * @param $path
-     *
+     * @param null|string $path
      * @return string
      */
     public function renderUrlFromPath($path = null)
@@ -165,8 +165,7 @@ class TwigExtension extends Twig_Extension implements \Twig_Extension_GlobalsInt
      * Generates: path/to/asset/name.ext?v=3
      *
      * @param string $path
-     * @param null   $version
-     *
+     * @param null|string $version
      * @return string
      */
     public function renderAssetUrl($path, $version = null)

--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -39,8 +39,6 @@ class TwigRenderer implements TemplateRendererInterface
     protected $template;
 
     /**
-     *  Constructor
-     *
      * @param TwigEnvironment $template
      * @param string          $suffix
      */
@@ -108,7 +106,8 @@ class TwigRenderer implements TemplateRendererInterface
      * Add a path for template
      *
      * @param string $path
-     * @param string $namespace
+     * @param null|string $namespace
+     * @return void
      */
     public function addPath($path, $namespace = null)
     {

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -8,7 +8,6 @@
 namespace Zend\Expressive\Twig;
 
 use ArrayObject;
-use DateTimeZone;
 use Interop\Container\ContainerInterface;
 use Twig_Environment as TwigEnvironment;
 

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -19,7 +19,6 @@ class TwigRendererFactory
 {
     /**
      * @param ContainerInterface $container
-     *
      * @return TwigRenderer
      * @throws Exception\InvalidConfigException for invalid config service values.
      */
@@ -40,7 +39,6 @@ class TwigRendererFactory
      * array having precedence.
      *
      * @param array|ArrayObject $config
-     *
      * @return array
      * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
      *     $config is received.

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -54,10 +54,10 @@ class TwigRendererFactory
             ));
         }
 
-        $expressiveConfig = (isset($config['templates']) && is_array($config['templates']))
+        $expressiveConfig = isset($config['templates']) && is_array($config['templates'])
             ? $config['templates']
             : [];
-        $twigConfig       = (isset($config['twig']) && is_array($config['twig']))
+        $twigConfig       = isset($config['twig']) && is_array($config['twig'])
             ? $config['twig']
             : [];
 

--- a/test/TwigEnvironmentFactoryTest.php
+++ b/test/TwigEnvironmentFactoryTest.php
@@ -315,11 +315,11 @@ class TwigEnvironmentFactoryTest extends TestCase
 
     public function testInjectsCustomRuntimeLoadersIntoTwigEnvironment()
     {
-        $fooRuntime = self::prophesize(TwigRuntimeLoaderInterface::class);
+        $fooRuntime = $this->prophesize(TwigRuntimeLoaderInterface::class);
         $fooRuntime->load('Test\Runtime\FooRuntime')->willReturn('foo-runtime');
         $fooRuntime->load('Test\Runtime\BarRuntime')->willReturn(null);
 
-        $barRuntime = self::prophesize(TwigRuntimeLoaderInterface::class);
+        $barRuntime = $this->prophesize(TwigRuntimeLoaderInterface::class);
         $barRuntime->load('Test\Runtime\BarRuntime')->willReturn('bar-runtime');
         $barRuntime->load('Test\Runtime\FooRuntime')->willReturn(null);
 

--- a/test/TwigEnvironmentFactoryTest.php
+++ b/test/TwigEnvironmentFactoryTest.php
@@ -12,6 +12,7 @@ use DateTimeZone;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ProphecyInterface;
 use Twig_Environment as TwigEnvironment;
+use Twig_Extension_Core as TwigExtensionCore;
 use Twig_RuntimeLoaderInterface as TwigRuntimeLoaderInterface;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
@@ -247,7 +248,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigEnvironmentFactory();
         $environment = $factory($this->container->reveal());
-        $fetchedTz = $environment->getExtension('core')->getTimezone();
+        $fetchedTz = $environment->getExtension(TwigExtensionCore::class)->getTimezone();
         $this->assertEquals(new DateTimeZone($tz), $fetchedTz);
     }
 

--- a/test/TwigEnvironmentFactoryTest.php
+++ b/test/TwigEnvironmentFactoryTest.php
@@ -153,8 +153,7 @@ class TwigEnvironmentFactoryTest extends TestCase
     public function testRaisesExceptionForInvalidExtensions($extension)
     {
         $config = [
-            'templates' => [
-            ],
+            'templates' => [],
             'twig'      => [
                 'extensions' => [$extension],
             ],
@@ -204,8 +203,7 @@ class TwigEnvironmentFactoryTest extends TestCase
 
     public function invalidConfiguration()
     {
-        // @codingStandardsIgnoreStart
-        //                        [Config value,                        Type ]
+        //                        [Config value, Type]
         return [
             'true'             => [true, 'boolean'],
             'false'            => [false, 'boolean'],
@@ -216,7 +214,6 @@ class TwigEnvironmentFactoryTest extends TestCase
             'string'           => ['not-configuration', 'string'],
             'non-array-object' => [(object) ['not' => 'configuration'], 'stdClass'],
         ];
-        // @codingStandardsIgnoreEnd
     }
 
     /**
@@ -241,8 +238,8 @@ class TwigEnvironmentFactoryTest extends TestCase
         $tz = DateTimeZone::listIdentifiers()[0];
         $config = [
             'twig' => [
-                'timezone' => $tz
-            ]
+                'timezone' => $tz,
+            ],
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
@@ -259,8 +256,8 @@ class TwigEnvironmentFactoryTest extends TestCase
         $tz = 'Luna/Copernicus_Crater';
         $config = [
             'twig' => [
-                'timezone' => $tz
-            ]
+                'timezone' => $tz,
+            ],
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
@@ -296,10 +293,9 @@ class TwigEnvironmentFactoryTest extends TestCase
     public function testRaisesExceptionForInvalidRuntimeLoaders($runtimeLoader)
     {
         $config = [
-            'templates' => [
-            ],
+            'templates' => [],
             'twig' => [
-                'runtime_loaders' => [ $runtimeLoader ],
+                'runtime_loaders' => [$runtimeLoader],
             ],
         ];
         $this->container->has('config')->willReturn(true);
@@ -328,8 +324,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         $barRuntime->load('Test\Runtime\FooRuntime')->willReturn(null);
 
         $config = [
-            'templates' => [
-            ],
+            'templates' => [],
             'twig' => [
                 'runtime_loaders' => [
                     $fooRuntime->reveal(),

--- a/test/TwigEnvironmentFactoryTest.php
+++ b/test/TwigEnvironmentFactoryTest.php
@@ -9,7 +9,8 @@ namespace ZendTest\Expressive\Twig;
 
 use Interop\Container\ContainerInterface;
 use DateTimeZone;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ProphecyInterface;
 use Twig_Environment as TwigEnvironment;
 use Twig_RuntimeLoaderInterface as TwigRuntimeLoaderInterface;
 use Zend\Expressive\Helper\ServerUrlHelper;
@@ -23,7 +24,7 @@ use Zend\Expressive\Twig\TwigExtension;
 class TwigEnvironmentFactoryTest extends TestCase
 {
     /**
-     * @var ContainerInterface
+     * @var ContainerInterface|ProphecyInterface
      */
     private $container;
 
@@ -63,6 +64,8 @@ class TwigEnvironmentFactoryTest extends TestCase
 
     /**
      * @depends testCallingFactoryWithNoConfigReturnsTwigEnvironmentInstance
+     *
+     * @param TwigEnvironment $environment
      */
     public function testDebugDisabledSetsUpEnvironmentForProduction(TwigEnvironment $environment)
     {
@@ -144,6 +147,8 @@ class TwigEnvironmentFactoryTest extends TestCase
 
     /**
      * @dataProvider invalidExtensions
+     *
+     * @param mixed $extension
      */
     public function testRaisesExceptionForInvalidExtensions($extension)
     {
@@ -165,7 +170,7 @@ class TwigEnvironmentFactoryTest extends TestCase
 
         $factory = new TwigEnvironmentFactory();
 
-        $this->setExpectedException(InvalidExtensionException::class);
+        $this->expectException(InvalidExtensionException::class);
         $factory($this->container->reveal());
     }
 
@@ -216,6 +221,9 @@ class TwigEnvironmentFactoryTest extends TestCase
 
     /**
      * @dataProvider invalidConfiguration
+     *
+     * @param mixed $config
+     * @param string $contains
      */
     public function testRaisesExceptionForInvalidConfigService($config, $contains)
     {
@@ -223,7 +231,8 @@ class TwigEnvironmentFactoryTest extends TestCase
         $this->container->get('config')->willReturn($config);
         $factory = new TwigEnvironmentFactory();
 
-        $this->setExpectedException(InvalidConfigException::class, $contains);
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage($contains);
         $factory($this->container->reveal());
     }
 
@@ -258,7 +267,8 @@ class TwigEnvironmentFactoryTest extends TestCase
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigEnvironmentFactory();
-        $this->setExpectedException(InvalidConfigException::class);
+
+        $this->expectException(InvalidConfigException::class);
         $factory($this->container->reveal());
     }
 
@@ -280,6 +290,8 @@ class TwigEnvironmentFactoryTest extends TestCase
 
     /**
      * @dataProvider invalidRuntimeLoaders
+     *
+     * @param mixed $runtimeLoader
      */
     public function testRaisesExceptionForInvalidRuntimeLoaders($runtimeLoader)
     {
@@ -301,7 +313,7 @@ class TwigEnvironmentFactoryTest extends TestCase
 
         $factory = new TwigEnvironmentFactory();
 
-        $this->setExpectedException(InvalidRuntimeLoaderException::class);
+        $this->expectException(InvalidRuntimeLoaderException::class);
         $factory($this->container->reveal());
     }
 

--- a/test/TwigExtensionFunctionsRenderTest.php
+++ b/test/TwigExtensionFunctionsRenderTest.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\Expressive\Twig;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Twig_Environment;
 use Twig_Loader_Array;
 use Twig_LoaderInterface;
@@ -34,6 +34,8 @@ class TwigExtensionFunctionsRenderTest extends TestCase
     }
 
     /**
+     * @param string $assetsUrl
+     * @param string $assetsVersion
      * @return Twig_Environment
      */
     protected function getTwigEnvironment($assetsUrl = '', $assetsVersion = '')
@@ -60,6 +62,13 @@ class TwigExtensionFunctionsRenderTest extends TestCase
 
     /**
      * @dataProvider renderPathProvider
+     *
+     * @param string $template
+     * @param string $route
+     * @param array $routeParams
+     * @param array $queryParams
+     * @param null|string $fragment
+     * @param array $options
      */
     public function testPathFunction(
         $template,
@@ -127,6 +136,13 @@ class TwigExtensionFunctionsRenderTest extends TestCase
 
     /**
      * @dataProvider renderUrlProvider
+     *
+     * @param string $template
+     * @param string $route
+     * @param array $routeParams
+     * @param array $queryParams
+     * @param null|string $fragment
+     * @param array $options
      */
     public function testUrlFunction(
         $template,

--- a/test/TwigExtensionTest.php
+++ b/test/TwigExtensionTest.php
@@ -7,7 +7,8 @@
 
 namespace ZendTest\Expressive\Twig;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ProphecyInterface;
 use Twig_SimpleFunction as SimpleFunction;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
@@ -15,6 +16,12 @@ use Zend\Expressive\Twig\TwigExtension;
 
 class TwigExtensionTest extends TestCase
 {
+    /** @var ServerUrlHelper|ProphecyInterface */
+    private $serverUrlHelper;
+
+    /** @var UrlHelper|ProphecyInterface */
+    private $urlHelper;
+
     public function setUp()
     {
         $this->serverUrlHelper = $this->prophesize(ServerUrlHelper::class);
@@ -133,6 +140,8 @@ class TwigExtensionTest extends TestCase
 
     /**
      * @dataProvider emptyAssetVersions
+     *
+     * @param null|string $emptyValue
      */
     public function testRenderAssetUrlWithoutProvidedVersion($emptyValue)
     {
@@ -153,6 +162,8 @@ class TwigExtensionTest extends TestCase
 
     /**
      * @dataProvider zeroAssetVersions
+     *
+     * @param int|string $zeroValue
      */
     public function testRendersZeroVersionAssetUrl($zeroValue)
     {

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -8,7 +8,8 @@
 namespace ZendTest\Expressive\Twig;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ProphecyInterface;
 use ReflectionProperty;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
@@ -21,7 +22,7 @@ use Twig_Environment as TwigEnvironment;
 class TwigRendererFactoryTest extends TestCase
 {
     /**
-     * @var ContainerInterface
+     * @var ContainerInterface|ProphecyInterface
      */
     private $container;
 
@@ -136,6 +137,8 @@ class TwigRendererFactoryTest extends TestCase
 
     /**
      * @depends testCallingFactoryWithNoConfigReturnsTwigInstance
+     *
+     * @param TwigRenderer $twig
      */
     public function testUnconfiguredTwigInstanceContainsNoPaths(TwigRenderer $twig)
     {

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -8,7 +8,6 @@
 namespace ZendTest\Expressive\Twig;
 
 use Interop\Container\ContainerInterface;
-use DateTimeZone;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
 use Zend\Expressive\Helper\ServerUrlHelper;

--- a/test/TwigRendererTest.php
+++ b/test/TwigRendererTest.php
@@ -67,14 +67,6 @@ class TwigRendererTest extends TestCase
         }
     }
 
-    public function testShouldInjectDefaultLoaderIfProvidedEnvironmentDoesNotComposeOne()
-    {
-        $twigEnvironment = new Twig_Environment();
-        $renderer        = new TwigRenderer($twigEnvironment);
-        $loader          = $twigEnvironment->getLoader();
-        $this->assertInstanceOf('Twig_Loader_Filesystem', $loader);
-    }
-
     public function testCanPassEngineToConstructor()
     {
         $renderer = new TwigRenderer($this->twigEnvironment);

--- a/test/TwigRendererTest.php
+++ b/test/TwigRendererTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\Expressive\Twig;
 
 use ArrayObject;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Twig_Environment;
 use Twig_Loader_Filesystem;
 use Zend\Expressive\Template\Exception;
@@ -24,7 +24,7 @@ class TwigRendererTest extends TestCase
 
     /**
      * @var Twig_Environment
-    */
+     */
     private $twigEnvironment;
 
     public function setUp()
@@ -95,7 +95,7 @@ class TwigRendererTest extends TestCase
         $renderer->addPath(__DIR__ . '/TestAsset');
         $paths = $renderer->getPaths();
         $this->assertInternalType('array', $paths);
-        $this->assertEquals(1, count($paths));
+        $this->assertCount(1, $paths);
         $this->assertTemplatePath(__DIR__ . '/TestAsset', $paths[0]);
         $this->assertTemplatePathString(__DIR__ . '/TestAsset', $paths[0]);
         $this->assertEmptyTemplatePathNamespace($paths[0]);
@@ -107,7 +107,7 @@ class TwigRendererTest extends TestCase
         $renderer->addPath(__DIR__ . '/TestAsset', 'test');
         $paths = $renderer->getPaths();
         $this->assertInternalType('array', $paths);
-        $this->assertEquals(1, count($paths));
+        $this->assertCount(1, $paths);
         $this->assertTemplatePath(__DIR__ . '/TestAsset', $paths[0]);
         $this->assertTemplatePathString(__DIR__ . '/TestAsset', $paths[0]);
         $this->assertTemplatePathNamespace('test', $paths[0]);
@@ -140,11 +140,13 @@ class TwigRendererTest extends TestCase
 
     /**
      * @dataProvider invalidParameterValues
+     *
+     * @param mixed $params
      */
     public function testRenderRaisesExceptionForInvalidParameterTypes($params)
     {
         $renderer = new TwigRenderer();
-        $this->setExpectedException(Exception\InvalidArgumentException::class);
+        $this->expectException(Exception\InvalidArgumentException::class);
         $renderer->render('foo', $params);
     }
 
@@ -172,6 +174,9 @@ class TwigRendererTest extends TestCase
 
     /**
      * @dataProvider objectParameterValues
+     *
+     * @param object $params
+     * @param string $search
      */
     public function testCanRenderWithParameterObjects($params, $search)
     {

--- a/test/TwigRendererTest.php
+++ b/test/TwigRendererTest.php
@@ -29,7 +29,7 @@ class TwigRendererTest extends TestCase
 
     public function setUp()
     {
-        $this->twigFilesystem  = new Twig_Loader_Filesystem;
+        $this->twigFilesystem  = new Twig_Loader_Filesystem();
         $this->twigEnvironment = new Twig_Environment($this->twigFilesystem);
     }
 


### PR DESCRIPTION
This PR is based on #27 and resolves #25.

The public interface is not changed so it could be released with 1.3.0 version.

Maybe will be worth to note that is not possible to use anymore aliases for extensions, just class name, so instead of:
```php
$environment->getExtension('core');
```
we have to do now:
```php
$environment->getExtension(Twig_Extension_Core::class);
```

In this PR we allow Twig `^1.31 || ^2.1`.