### PR TITLE
Optional twig extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.0.0alpha2 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- [#43](https://github.com/zendframework/zend-expressive-twigrenderer/pull/43)
+  adds a TwigExtensionFactory so the TwigExtension can be customized. 
+  
+  If you have the ConfigProvider in your `config\config.php` file, this factory 
+  is added for you. If you don't use the ConfigProvider, you need to add this 
+  to your config:
+  
+  ```php
+  'dependencies' => [  
+      'factories' => [
+          TwigExtension::class => TwigExtensionFactory::class,
+      ],
+  ],
+  ```
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 2.0.0alpha1 - 2018-02-06
 
 ### Added

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2017, Zend Technologies USA, Inc.
+Copyright (c) 2015-2018, Zend Technologies USA, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ are registered with the container.
 
 If you use the [zend-component-installer](https://github.com/zendframework/zend-component-installer) 
 the factories are configured automatically for you when requiring this package
-wit composer. Without the component installer, you need to 
-include the `[ConfigProvider](src/ConfigProvider.php)` in your 
-`[config/config.php](https://github.com/zendframework/zend-expressive-skeleton/blob/master/config/config.php)`. 
+with composer. Without the component installer, you need to 
+include the [`ConfigProvider`](src/ConfigProvider.php) in your 
+[`config/config.php`](https://github.com/zendframework/zend-expressive-skeleton/blob/master/config/config.php). 
 Optional configuration can be stored in `config/autoload/templates.global.php`.
 
 ```php

--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ are registered with the container.
 
 ## Configuration
 
+If you use the [zend-component-installer](https://github.com/zendframework/zend-component-installer) 
+the factories are configured automatically for you when requiring this package
+wit composer. Without the component installer, you need to 
+include the `[ConfigProvider](src/ConfigProvider.php)` in your 
+`[config/config.php](https://github.com/zendframework/zend-expressive-skeleton/blob/master/config/config.php)`. 
+Optional configuration can be stored in `config/autoload/templates.global.php`.
+
 ```php
 'templates' => [
     'extension' => 'file extension used by templates; defaults to html.twig',

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-twigrenderer for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/LICENSE.md New BSD License
  */
 
@@ -18,19 +18,20 @@ class ConfigProvider
     {
         return [
             'dependencies' => $this->getDependencies(),
-            'templates' => $this->getTemplates(),
+            'templates'    => $this->getTemplates(),
         ];
     }
 
     public function getDependencies() : array
     {
         return [
-            'aliases' => [
+            'aliases'   => [
                 TemplateRendererInterface::class => TwigRenderer::class,
             ],
             'factories' => [
                 Twig_Environment::class => TwigEnvironmentFactory::class,
-                TwigRenderer::class => TwigRendererFactory::class,
+                TwigExtension::class    => TwigExtensionFactory::class,
+                TwigRenderer::class     => TwigRendererFactory::class,
             ],
         ];
     }
@@ -39,7 +40,7 @@ class ConfigProvider
     {
         return [
             'extension' => 'html.twig',
-            'paths' => [],
+            'paths'     => [],
         ];
     }
 }

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -247,7 +247,7 @@ class TwigEnvironmentFactory
 
         if (! is_array($config)) {
             throw new Exception\InvalidConfigException(sprintf(
-                'config service MUST be an array or ArrayObject; received %s',
+                'Config service MUST be an array or ArrayObject; received %s',
                 is_object($config) ? get_class($config) : gettype($config)
             ));
         }

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -252,10 +252,10 @@ class TwigEnvironmentFactory
             ));
         }
 
-        $expressiveConfig = (isset($config['templates']) && is_array($config['templates']))
+        $expressiveConfig = isset($config['templates']) && is_array($config['templates'])
             ? $config['templates']
             : [];
-        $twigConfig = (isset($config['twig']) && is_array($config['twig']))
+        $twigConfig       = isset($config['twig']) && is_array($config['twig'])
             ? $config['twig']
             : [];
 

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-twigrenderer for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -77,9 +77,9 @@ class TwigEnvironmentFactory
             ));
         }
 
-        $debug    = array_key_exists('debug', $config) ? (bool) $config['debug'] : false;
+        $debug    = (bool) ($config['debug'] ?? false);
         $config   = TwigRendererFactory::mergeConfig($config);
-        $cacheDir = isset($config['cache_dir']) ? $config['cache_dir'] : false;
+        $cacheDir = $config['cache_dir'] ?? false;
 
         // Create the engine instance
         $loader      = new TwigLoader();
@@ -117,13 +117,13 @@ class TwigEnvironmentFactory
         }
 
         // Add user defined extensions
-        $extensions = (isset($config['extensions']) && is_array($config['extensions']))
+        $extensions = isset($config['extensions']) && is_array($config['extensions'])
             ? $config['extensions']
             : [];
         $this->injectExtensions($environment, $container, $extensions);
 
         // Add user defined runtime loaders
-        $runtimeLoaders = (isset($config['runtime_loaders']) && is_array($config['runtime_loaders']))
+        $runtimeLoaders = isset($config['runtime_loaders']) && is_array($config['runtime_loaders'])
             ? $config['runtime_loaders']
             : [];
         $this->injectRuntimeLoaders($environment, $container, $runtimeLoaders);

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -78,7 +78,7 @@ class TwigEnvironmentFactory
         }
 
         $debug    = array_key_exists('debug', $config) ? (bool) $config['debug'] : false;
-        $config   = $this->mergeConfig($config);
+        $config   = TwigRendererFactory::mergeConfig($config);
         $cacheDir = isset($config['cache_dir']) ? $config['cache_dir'] : false;
 
         // Create the engine instance
@@ -228,37 +228,5 @@ class TwigEnvironmentFactory
         }
 
         return $runtimeLoader;
-    }
-
-    /**
-     * Merge expressive templating config with twig config.
-     *
-     * Pulls the `templates` and `twig` top-level keys from the configuration,
-     * if present, and then returns the merged result, with those from the twig
-     * array having precedence.
-     *
-     * @param array|ArrayObject $config
-     * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
-     *     $config is received.
-     */
-    private function mergeConfig($config) : array
-    {
-        $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
-
-        if (! is_array($config)) {
-            throw new Exception\InvalidConfigException(sprintf(
-                'Config service MUST be an array or ArrayObject; received %s',
-                is_object($config) ? get_class($config) : gettype($config)
-            ));
-        }
-
-        $expressiveConfig = isset($config['templates']) && is_array($config['templates'])
-            ? $config['templates']
-            : [];
-        $twigConfig       = isset($config['twig']) && is_array($config['twig'])
-            ? $config['twig']
-            : [];
-
-        return array_replace_recursive($expressiveConfig, $twigConfig);
     }
 }

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -103,15 +103,12 @@ class TwigEnvironmentFactory
             $environment->getExtension(TwigExtensionCore::class)->setTimezone($timezone);
         }
 
-        // Add expressive twig extension
-        if ($container->has(ServerUrlHelper::class) && $container->has(UrlHelper::class)) {
-            $environment->addExtension(new TwigExtension(
-                $container->get(ServerUrlHelper::class),
-                $container->get(UrlHelper::class),
-                isset($config['assets_url']) ? $config['assets_url'] : '',
-                isset($config['assets_version']) ? $config['assets_version'] : '',
-                isset($config['globals']) ? $config['globals'] : []
-            ));
+        // Add expressive twig extension if requirements are met
+        if ($container->has(TwigExtension::class)
+            && $container->has(ServerUrlHelper::class)
+            && $container->has(UrlHelper::class)
+        ) {
+            $environment->addExtension($container->get(TwigExtension::class));
         }
 
         // Add debug extension

--- a/src/TwigExtensionFactory.php
+++ b/src/TwigExtensionFactory.php
@@ -62,7 +62,7 @@ class TwigExtensionFactory
 
         if (! is_array($config)) {
             throw new Exception\InvalidConfigException(sprintf(
-                'config service MUST be an array or ArrayObject; received %s',
+                'Config service MUST be an array or ArrayObject; received %s',
                 is_object($config) ? get_class($config) : gettype($config)
             ));
         }

--- a/src/TwigExtensionFactory.php
+++ b/src/TwigExtensionFactory.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-twigrenderer for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Twig;
+
+use ArrayObject;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Twig\Exception\InvalidConfigException;
+
+class TwigExtensionFactory
+{
+    public function __invoke(ContainerInterface $container) : TwigExtension
+    {
+        if (! $container->has(ServerUrlHelper::class)) {
+            throw new InvalidConfigException(sprintf(
+                'Missing required `%s` dependency.',
+                ServerUrlHelper::class
+            ));
+        }
+
+        if (! $container->has(UrlHelper::class)) {
+            throw new InvalidConfigException(sprintf(
+                'Missing required `%s` dependency.',
+                UrlHelper::class
+            ));
+        }
+
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = $this->mergeConfig($config);
+
+        return new TwigExtension(
+            $container->get(ServerUrlHelper::class),
+            $container->get(UrlHelper::class),
+            $config['assets_url'] ?? '',
+            $config['assets_version'] ?? '',
+            $config['globals'] ?? []
+        );
+    }
+
+    /**
+     * Merge expressive templating config with twig config.
+     *
+     * Pulls the `templates` and `twig` top-level keys from the configuration,
+     * if present, and then returns the merged result, with those from the twig
+     * array having precedence.
+     *
+     * @param array|ArrayObject $config
+     * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
+     *     $config is received.
+     */
+    private function mergeConfig($config) : array
+    {
+        $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
+
+        if (! is_array($config)) {
+            throw new Exception\InvalidConfigException(sprintf(
+                'config service MUST be an array or ArrayObject; received %s',
+                is_object($config) ? get_class($config) : gettype($config)
+            ));
+        }
+
+        $expressiveConfig = (isset($config['templates']) && is_array($config['templates']))
+            ? $config['templates']
+            : [];
+        $twigConfig       = (isset($config['twig']) && is_array($config['twig']))
+            ? $config['twig']
+            : [];
+
+        return array_replace_recursive($expressiveConfig, $twigConfig);
+    }
+}

--- a/src/TwigExtensionFactory.php
+++ b/src/TwigExtensionFactory.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Twig;
 
-use ArrayObject;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
@@ -34,7 +33,7 @@ class TwigExtensionFactory
         }
 
         $config = $container->has('config') ? $container->get('config') : [];
-        $config = $this->mergeConfig($config);
+        $config = TwigRendererFactory::mergeConfig($config);
 
         return new TwigExtension(
             $container->get(ServerUrlHelper::class),
@@ -43,37 +42,5 @@ class TwigExtensionFactory
             $config['assets_version'] ?? '',
             $config['globals'] ?? []
         );
-    }
-
-    /**
-     * Merge expressive templating config with twig config.
-     *
-     * Pulls the `templates` and `twig` top-level keys from the configuration,
-     * if present, and then returns the merged result, with those from the twig
-     * array having precedence.
-     *
-     * @param array|ArrayObject $config
-     * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
-     *     $config is received.
-     */
-    private function mergeConfig($config) : array
-    {
-        $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
-
-        if (! is_array($config)) {
-            throw new Exception\InvalidConfigException(sprintf(
-                'Config service MUST be an array or ArrayObject; received %s',
-                is_object($config) ? get_class($config) : gettype($config)
-            ));
-        }
-
-        $expressiveConfig = isset($config['templates']) && is_array($config['templates'])
-            ? $config['templates']
-            : [];
-        $twigConfig       = isset($config['twig']) && is_array($config['twig'])
-            ? $config['twig']
-            : [];
-
-        return array_replace_recursive($expressiveConfig, $twigConfig);
     }
 }

--- a/src/TwigExtensionFactory.php
+++ b/src/TwigExtensionFactory.php
@@ -67,10 +67,10 @@ class TwigExtensionFactory
             ));
         }
 
-        $expressiveConfig = (isset($config['templates']) && is_array($config['templates']))
+        $expressiveConfig = isset($config['templates']) && is_array($config['templates'])
             ? $config['templates']
             : [];
-        $twigConfig       = (isset($config['twig']) && is_array($config['twig']))
+        $twigConfig       = isset($config['twig']) && is_array($config['twig'])
             ? $config['twig']
             : [];
 

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -47,7 +47,7 @@ class TwigRendererFactory
 
         if (! is_array($config)) {
             throw new Exception\InvalidConfigException(sprintf(
-                'config service MUST be an array or ArrayObject; received %s',
+                'Config service MUST be an array or ArrayObject; received %s',
                 is_object($config) ? get_class($config) : gettype($config)
             ));
         }

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-twigrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -27,7 +27,7 @@ class TwigRendererFactory
         $config      = self::mergeConfig($config);
         $environment = $this->getEnvironment($container);
 
-        return new TwigRenderer($environment, isset($config['extension']) ? $config['extension'] : 'html.twig');
+        return new TwigRenderer($environment, $config['extension'] ?? 'html.twig');
     }
 
     /**

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -24,7 +24,7 @@ class TwigRendererFactory
     public function __invoke(ContainerInterface $container) : TwigRenderer
     {
         $config      = $container->has('config') ? $container->get('config') : [];
-        $config      = $this->mergeConfig($config);
+        $config      = self::mergeConfig($config);
         $environment = $this->getEnvironment($container);
 
         return new TwigRenderer($environment, isset($config['extension']) ? $config['extension'] : 'html.twig');
@@ -41,7 +41,7 @@ class TwigRendererFactory
      * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
      *     $config is received.
      */
-    private function mergeConfig($config) : array
+    public static function mergeConfig($config) : array
     {
         $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
 

--- a/test/TwigEnvironmentFactoryTest.php
+++ b/test/TwigEnvironmentFactoryTest.php
@@ -236,9 +236,6 @@ class TwigEnvironmentFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
-        $this->container->has(TwigExtension::class)->willReturn(false);
-        $this->container->has(ServerUrlHelper::class)->willReturn(false);
-        $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigEnvironmentFactory();
 
         $this->expectException(InvalidConfigException::class);

--- a/test/TwigEnvironmentFactoryTest.php
+++ b/test/TwigEnvironmentFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-twigrenderer for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/LICENSE.md New BSD License
  */
 
@@ -23,6 +23,7 @@ use Zend\Expressive\Twig\Exception\InvalidExtensionException;
 use Zend\Expressive\Twig\Exception\InvalidRuntimeLoaderException;
 use Zend\Expressive\Twig\TwigEnvironmentFactory;
 use Zend\Expressive\Twig\TwigExtension;
+use Zend\Expressive\Twig\TwigExtensionFactory;
 
 class TwigEnvironmentFactoryTest extends TestCase
 {
@@ -39,6 +40,7 @@ class TwigEnvironmentFactoryTest extends TestCase
     public function testCallingFactoryWithNoConfigReturnsTwigEnvironmentInstance()
     {
         $this->container->has('config')->willReturn(false);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $factory     = new TwigEnvironmentFactory();
@@ -54,6 +56,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         $config = ['debug' => true];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $factory     = new TwigEnvironmentFactory();
@@ -82,6 +85,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         $config = ['templates' => ['cache_dir' => __DIR__]];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $factory     = new TwigEnvironmentFactory();
@@ -92,6 +96,7 @@ class TwigEnvironmentFactoryTest extends TestCase
 
     public function testAddsTwigExtensionIfRouterIsInContainer()
     {
+        $twigExtensionFactory = new TwigExtensionFactory();
         $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
         $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
         $this->container->has('config')->willReturn(false);
@@ -99,37 +104,12 @@ class TwigEnvironmentFactoryTest extends TestCase
         $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
         $this->container->has(UrlHelper::class)->willReturn(true);
         $this->container->get(UrlHelper::class)->willReturn($urlHelper);
+        $this->container->has(TwigExtension::class)->willReturn(true);
+        $this->container->get(TwigExtension::class)->willReturn($twigExtensionFactory($this->container->reveal()));
         $factory     = new TwigEnvironmentFactory();
         $environment = $factory($this->container->reveal());
 
         $this->assertTrue($environment->hasExtension(TwigExtension::class));
-    }
-
-    public function testUsesAssetsConfigurationWhenAddingTwigExtension()
-    {
-        $config          = [
-            'templates' => [
-                'assets_url'     => 'http://assets.example.com/',
-                'assets_version' => 'XYZ',
-            ],
-        ];
-        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
-        $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(ServerUrlHelper::class)->willReturn(true);
-        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
-        $this->container->has(UrlHelper::class)->willReturn(true);
-        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
-        $factory     = new TwigEnvironmentFactory();
-        $environment = $factory($this->container->reveal());
-        $extension   = $environment->getExtension(TwigExtension::class);
-
-        $this->assertInstanceOf(TwigExtension::class, $extension);
-        $this->assertAttributeEquals($config['templates']['assets_url'], 'assetsUrl', $extension);
-        $this->assertAttributeEquals($config['templates']['assets_version'], 'assetsVersion', $extension);
-        $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $extension);
-        $this->assertAttributeSame($urlHelper, 'urlHelper', $extension);
     }
 
     public function invalidExtensions()
@@ -163,6 +143,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
 
@@ -174,34 +155,6 @@ class TwigEnvironmentFactoryTest extends TestCase
 
         $this->expectException(InvalidExtensionException::class);
         $factory($this->container->reveal());
-    }
-
-    public function testConfiguresGlobals()
-    {
-        $config          = [
-            'twig' => [
-                'globals' => [
-                    'ga_tracking' => 'UA-XXXXX-X',
-                    'foo'         => 'bar',
-                ],
-            ],
-        ];
-        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
-        $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(ServerUrlHelper::class)->willReturn(true);
-        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
-        $this->container->has(UrlHelper::class)->willReturn(true);
-        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
-        $factory     = new TwigEnvironmentFactory();
-        $environment = $factory($this->container->reveal());
-        $extension   = $environment->getExtension(TwigExtension::class);
-
-        $this->assertInstanceOf(TwigExtension::class, $extension);
-        $this->assertAttributeEquals($config['twig']['globals'], 'globals', $extension);
-        $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $extension);
-        $this->assertAttributeSame($urlHelper, 'urlHelper', $extension);
     }
 
     public function invalidConfiguration()
@@ -246,6 +199,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigEnvironmentFactory();
@@ -264,6 +218,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $factory = new TwigEnvironmentFactory();
@@ -303,6 +258,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
 
@@ -337,6 +293,7 @@ class TwigEnvironmentFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $this->container->has('Test\Runtime\BarRuntimeLoader')->willReturn(true);

--- a/test/TwigEnvironmentFactoryTest.php
+++ b/test/TwigEnvironmentFactoryTest.php
@@ -227,6 +227,26 @@ class TwigEnvironmentFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
+    public function testRaisesExceptionForNonStringTimezone()
+    {
+        $config = [
+            'twig' => [
+                'timezone' => new DateTimeZone('UTC'),
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
+        $factory = new TwigEnvironmentFactory();
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('"timezone" configuration value must be a string');
+
+        $factory($this->container->reveal());
+    }
+
     public function invalidRuntimeLoaders()
     {
         return [

--- a/test/TwigExtensionFactoryTest.php
+++ b/test/TwigExtensionFactoryTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-twigrenderer for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ProphecyInterface;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Helper\ServerUrlHelper;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Twig\TwigExtension;
+use Zend\Expressive\Twig\TwigExtensionFactory;
+
+class TwigExtensionFactoryTest extends TestCase
+{
+    /**
+     * @var ContainerInterface|ProphecyInterface
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function testUsesAssetsConfigurationWhenAddingTwigExtension()
+    {
+        $config = [
+            'templates' => [
+                'assets_url'     => 'http://assets.example.com/',
+                'assets_version' => 'XYZ',
+            ],
+        ];
+
+        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
+        $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
+        $factory   = new TwigExtensionFactory();
+        $extension = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(TwigExtension::class, $extension);
+        $this->assertAttributeEquals($config['templates']['assets_url'], 'assetsUrl', $extension);
+        $this->assertAttributeEquals($config['templates']['assets_version'], 'assetsVersion', $extension);
+        $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $extension);
+        $this->assertAttributeSame($urlHelper, 'urlHelper', $extension);
+    }
+
+    public function testConfiguresGlobals()
+    {
+        $config = [
+            'twig' => [
+                'globals' => [
+                    'ga_tracking' => 'UA-XXXXX-X',
+                    'foo'         => 'bar',
+                ],
+            ],
+        ];
+
+        $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
+        $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
+        $factory   = new TwigExtensionFactory();
+        $extension = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(TwigExtension::class, $extension);
+        $this->assertAttributeEquals($config['twig']['globals'], 'globals', $extension);
+        $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $extension);
+        $this->assertAttributeSame($urlHelper, 'urlHelper', $extension);
+    }
+}

--- a/test/TwigExtensionFactoryTest.php
+++ b/test/TwigExtensionFactoryTest.php
@@ -121,22 +121,4 @@ class TwigExtensionFactoryTest extends TestCase
         $this->assertAttributeSame($this->serverUrlHelper->reveal(), 'serverUrlHelper', $extension);
         $this->assertAttributeSame($this->urlHelper->reveal(), 'urlHelper', $extension);
     }
-
-    public function testRaisesExceptionForInvalidConfig()
-    {
-        $config = 'foo';
-
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-        $this->container->has(ServerUrlHelper::class)->willReturn(true);
-        $this->container->get(ServerUrlHelper::class)->willReturn($this->serverUrlHelper->reveal());
-        $this->container->has(UrlHelper::class)->willReturn(true);
-        $this->container->get(UrlHelper::class)->willReturn($this->urlHelper->reveal());
-
-        $this->expectException(InvalidConfigException::class);
-        $this->expectExceptionMessage('Config service MUST be an array or ArrayObject; received string');
-
-        $factory = new TwigExtensionFactory();
-        $factory($this->container->reveal());
-    }
 }

--- a/test/TwigExtensionFactoryTest.php
+++ b/test/TwigExtensionFactoryTest.php
@@ -52,13 +52,13 @@ class TwigExtensionFactoryTest extends TestCase
             ServerUrlHelper::class
         ));
 
-        (new TwigExtensionFactory())($this->container->reveal());
+        $factory = new TwigExtensionFactory();
+        $factory($this->container->reveal());
     }
 
     public function testRaisesExceptionForMissingUrlHelper()
     {
         $this->container->has(ServerUrlHelper::class)->willReturn(true);
-        $this->container->get(ServerUrlHelper::class)->willReturn($this->serverUrlHelper->reveal());
         $this->container->has(UrlHelper::class)->willReturn(false);
 
         $this->expectException(InvalidConfigException::class);
@@ -67,7 +67,8 @@ class TwigExtensionFactoryTest extends TestCase
             UrlHelper::class
         ));
 
-        (new TwigExtensionFactory())($this->container->reveal());
+        $factory = new TwigExtensionFactory();
+        $factory($this->container->reveal());
     }
 
     public function testUsesAssetsConfigurationWhenAddingTwigExtension()
@@ -135,6 +136,7 @@ class TwigExtensionFactoryTest extends TestCase
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Config service MUST be an array or ArrayObject; received string');
 
-        (new TwigExtensionFactory())($this->container->reveal());
+        $factory = new TwigExtensionFactory();
+        $factory($this->container->reveal());
     }
 }

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -237,10 +237,6 @@ class TwigRendererFactoryTest extends TestCase
 
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
-        $this->container->has(TwigExtension::class)->willReturn(false);
-        $this->container->has(ServerUrlHelper::class)->willReturn(false);
-        $this->container->has(UrlHelper::class)->willReturn(false);
-        $this->container->has(TwigEnvironment::class)->willReturn(false);
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Config service MUST be an array or ArrayObject; received string');

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -17,6 +17,7 @@ use Twig_Environment as TwigEnvironment;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Template\TemplatePath;
+use Zend\Expressive\Twig\Exception\InvalidConfigException;
 use Zend\Expressive\Twig\TwigEnvironmentFactory;
 use Zend\Expressive\Twig\TwigExtension;
 use Zend\Expressive\Twig\TwigRenderer;
@@ -228,5 +229,22 @@ class TwigRendererFactoryTest extends TestCase
 
         $twig = $factory($this->container->reveal());
         $this->assertInstanceOf(TwigRenderer::class, $twig);
+    }
+
+    public function testRaisesExceptionForInvalidConfig()
+    {
+        $config = 'foo';
+
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
+        $this->container->has(TwigEnvironment::class)->willReturn(false);
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('Config service MUST be an array or ArrayObject; received string');
+
+        (new TwigRendererFactory())($this->container->reveal());
     }
 }

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -241,6 +241,7 @@ class TwigRendererFactoryTest extends TestCase
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Config service MUST be an array or ArrayObject; received string');
 
-        (new TwigRendererFactory())($this->container->reveal());
+        $factory = new TwigRendererFactory();
+        $factory($this->container->reveal());
     }
 }

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-twigrenderer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/LICENSE.md New BSD License
  */
 
@@ -18,6 +18,7 @@ use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Template\TemplatePath;
 use Zend\Expressive\Twig\TwigEnvironmentFactory;
+use Zend\Expressive\Twig\TwigExtension;
 use Zend\Expressive\Twig\TwigRenderer;
 use Zend\Expressive\Twig\TwigRendererFactory;
 
@@ -122,6 +123,7 @@ class TwigRendererFactoryTest extends TestCase
     public function testCallingFactoryWithNoConfigReturnsTwigInstance()
     {
         $this->container->has('config')->willReturn(false);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $environment = new TwigEnvironmentFactory();
@@ -158,6 +160,7 @@ class TwigRendererFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $environment = new TwigEnvironmentFactory();
@@ -180,6 +183,7 @@ class TwigRendererFactoryTest extends TestCase
         ];
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $environment = new TwigEnvironmentFactory();
@@ -210,6 +214,7 @@ class TwigRendererFactoryTest extends TestCase
     public function testCallingFactoryWithoutTwigEnvironmentServiceEmitsDeprecationNotice()
     {
         $this->container->has('config')->willReturn(false);
+        $this->container->has(TwigExtension::class)->willReturn(false);
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(UrlHelper::class)->willReturn(false);
         $this->container->has(TwigEnvironment::class)->willReturn(false);

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -231,17 +231,40 @@ class TwigRendererFactoryTest extends TestCase
         $this->assertInstanceOf(TwigRenderer::class, $twig);
     }
 
-    public function testRaisesExceptionForInvalidConfig()
+    public function testMergeConfigRaisesExceptionForInvalidConfig()
     {
-        $config = 'foo';
-
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn($config);
-
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Config service MUST be an array or ArrayObject; received string');
 
-        $factory = new TwigRendererFactory();
-        $factory($this->container->reveal());
+        TwigRendererFactory::mergeConfig('foo');
+    }
+
+    public function testMergesConfigCorrectly()
+    {
+        $config = [
+            'templates' => [
+                'extension' => 'file extension used by templates; defaults to html.twig',
+                'paths' => [],
+            ],
+            'twig' => [
+                'cache_dir' => 'path to cached templates',
+                'assets_url' => 'base URL for assets',
+                'assets_version' => 'base version for assets',
+                'extensions' => [],
+                'runtime_loaders' => [],
+                'globals' => ['ga_tracking' => 'UA-XXXXX-X'],
+                'timezone' => 'default timezone identifier, e.g.: America/New_York',
+            ],
+        ];
+
+        $mergedConfig = TwigRendererFactory::mergeConfig($config);
+
+        $this->assertArrayHasKey('extension', $mergedConfig);
+        $this->assertArrayHasKey('paths', $mergedConfig);
+        $this->assertArrayHasKey('cache_dir', $mergedConfig);
+        $this->assertArrayHasKey('assets_version', $mergedConfig);
+        $this->assertArrayHasKey('runtime_loaders', $mergedConfig);
+        $this->assertArrayHasKey('globals', $mergedConfig);
+        $this->assertArrayHasKey('timezone', $mergedConfig);
     }
 }


### PR DESCRIPTION
This PR adds a TwigExtensionFactory so you can override the TwigExtension if you want. Currently you cannot change the default `absolute_url`, `asset`, `path` and `url` functions. By using an extension factory you can extend and change the default extension or completely replace it.

Currently, it still is hardcoded in the TwigEnvironmentFactory. Ideally, this extension should be loaded as a regular extension. However doing so, it can't be enabled by default as it requires the `ServerUrlHelper` and `UrlHelper`. When adding it to the ConfigProvider we can't check if both dependencies are available or exit silently as the container should throw an exception if no service is returned.

Fixes #41

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.