### PR TITLE
Allow overriding optimizations and autoescape options via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Optional configuration can be stored in `config/autoload/templates.global.php`.
         'ga_tracking' => 'UA-XXXXX-X'
     ],
     'timezone' => 'default timezone identifier, e.g.: America/New_York',
+    'optimizations' => -1, // -1: Enable all (default), 0: disable optimizations
+    'autoescape' => 'html', // Auto-escaping strategy [html|js|css|url|false]
 ],
 ```
 

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -17,6 +17,7 @@ use Twig_Extension_Core as TwigExtensionCore;
 use Twig_Extension_Debug as TwigExtensionDebug;
 use Twig_ExtensionInterface as TwigExtensionInterface;
 use Twig_Loader_Filesystem as TwigLoader;
+use Twig_NodeVisitor_Optimizer as TwigOptimizer;
 use Twig_RuntimeLoaderInterface as TwigRuntimeLoaderInterface;
 use Zend\Expressive\Helper\ServerUrlHelper;
 use Zend\Expressive\Helper\UrlHelper;
@@ -96,6 +97,8 @@ class TwigEnvironmentFactory
             'debug'            => $debug,
             'strict_variables' => $debug,
             'auto_reload'      => $debug,
+            'optimizations'    => $config['optimizations'] ?? TwigOptimizer::OPTIMIZE_ALL,
+            'autoescape'       => $config['autoescape'] ?? 'html',
         ]);
 
         if (isset($config['timezone'])) {

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -62,6 +62,8 @@ use function sprintf;
  *         'ga_tracking' => 'UA-XXXXX-X'
  *     ],
  *     'timezone' => 'default timezone identifier, e.g.: America/New_York',
+ *     'optimizations' => -1, // -1: Enable all (default), 0: disable optimizations
+ *     'autoescape' => 'html', // Auto-escaping strategy [html|js|css|url|false]
  * ],
  * </code>
  *


### PR DESCRIPTION
Twig Environment provides following [additional options](https://twig.symfony.com/doc/2.x/api.html#environment-options) for developers:

 - `autoescape (string)` - Sets the default auto-escaping strategy (name, html, js, css, url, html_attr, or a PHP callback that takes the template "filename" and returns the escaping strategy to use -- the callback cannot be a function name to avoid collision with built-in escaping strategies); set it to false to disable auto-escaping.
 - `optimizations (int)`  - A flag that indicates which optimizations to apply (default to `-1` -- all optimizations are enabled; set it to 0 to disable).

`TwigEnvironmentFactory` currently creating a new Environment instance using a [limited list of options](https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/src/TwigEnvironmentFactory.php#L94-L99) and Environment has no interface to set these options later but the construction.

This PR provides a compatible way for disabling optimizations and auto-escaping (which enabled by default) using configration:

```php
$config = [
    'twig' = [
          'timezone'       => 'UTC',
          'cache_dir'      => 'data/cache/twig',
          // ... after all others
          'autoescape'     => false, // 'html' by default
          'optimizations'  => 0, // -1 by default
    ],
];
```
I have also wrote two test cases for these new options and considered using same values as Twig defaults in factory.

Only detail that bugging me is if Twig decides to change these defaults in a future release, `TwigEnvironmentFactory` would also need to be adjusted to reflect this changes.