### PR TITLE
Ability to attach simple filters via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Optional configuration can be stored in `config/autoload/templates.global.php`.
     'extensions' => [
         // extension service names or instances
     ],
+    'filters' => [
+        // user defined filters
+    ],
     'runtime_loaders' => [
         // runtime loaders names or instances   
     ],

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -58,6 +58,12 @@ use function sprintf;
  *     'runtime_loaders' => [
  *         // runtime loaders names or instances
  *     ],
+ *     'filters' => [
+ *          // user defined filters
+ *          ['name' => 'greet', 'filter' => function($a) { return 'Hello ' . $a; } ],
+ *          ['name' => 'mul', 'filter' => 'Math::multiply', 'options' => ['needs_context' => true] ],
+ *          ['name' => 'uglify', 'filter' => \Lib\Twig\Filter\Uglify::class ],
+ *      ],
  *     'globals' => [
  *         // Global variables passed to twig templates
  *         'ga_tracking' => 'UA-XXXXX-X'
@@ -145,6 +151,12 @@ class TwigEnvironmentFactory
             ? $config['runtime_loaders']
             : [];
         $this->injectRuntimeLoaders($environment, $container, $runtimeLoaders);
+
+        // Add user defined filters
+        $filters = isset($config['filters']) && is_array($config['filters'])
+            ? $config['filters']
+            : [];
+        $this->injectFilters($environment, $container, $filters);
 
         // Add template paths
         $allPaths = isset($config['paths']) && is_array($config['paths']) ? $config['paths'] : [];
@@ -253,5 +265,12 @@ class TwigEnvironmentFactory
         }
 
         return $runtimeLoader;
+    }
+
+    private function injectFilters(Environment $environment, ContainerInterface $container, array $filters): void
+    {
+        foreach ($filters as $filter) {
+            $environment->addFilter(TwigFilterFactory::createFilterFromConfig($container, $filter));
+        }
     }
 }

--- a/src/TwigFilterFactory.php
+++ b/src/TwigFilterFactory.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-twigrenderer for the canonical source repository
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Twig;
+
+use Psr\Container\ContainerInterface;
+use Twig\TwigFilter;
+
+use function array_key_exists;
+use function is_array;
+use function is_callable;
+use function is_string;
+
+/**
+ * Create and return a Twig filter instances
+ */
+class TwigFilterFactory
+{
+    public static function createFilterFromConfig(ContainerInterface $container, array $filterConfig): TwigFilter
+    {
+        if (! array_key_exists('name', $filterConfig) || ! array_key_exists('filter', $filterConfig)) {
+            throw new Exception\InvalidConfigException(
+                'Both "name" and "filter" keys are mandatory when defining twig filters'
+            );
+        }
+
+        $filter = $filterConfig['filter'];
+
+        if (is_string($filter) && $container->has($filter)) {
+            return $container->get($filter);
+        }
+
+        if (! is_array($filter) && ! is_callable($filter)) {
+            throw new Exception\InvalidConfigException(
+                'Key "filter" of a twig filter config should be a callable, native function or fully qualified class name'
+            );
+        }
+
+        return new TwigFilter($filterConfig['name'], $filter, $filterConfig['options'] ?? []);
+    }
+}

--- a/src/TwigFilterFactory.php
+++ b/src/TwigFilterFactory.php
@@ -38,7 +38,8 @@ class TwigFilterFactory
 
         if (! is_array($filter) && ! is_callable($filter)) {
             throw new Exception\InvalidConfigException(
-                'Key "filter" of a twig filter config should be a callable, native function or fully qualified class name'
+                'Key "filter" of a twig filter config should be a callable, '
+                . 'native function or fully qualified class name'
             );
         }
 

--- a/test/TwigFilterFactoryTest.php
+++ b/test/TwigFilterFactoryTest.php
@@ -66,11 +66,13 @@ class TwigFilterFactoryTest extends TestCase
             ],
             [
                 [ 'name' => 'bar', 'filter' => true ],
-                'Key "filter" of a twig filter config should be a callable, native function or fully qualified class name'
+                'Key "filter" of a twig filter config should be a callable, '
+                 . 'native function or fully qualified class name'
             ],
             [
                 [ 'name' => 'bar', 'filter' => 42 ],
-                'Key "filter" of a twig filter config should be a callable, native function or fully qualified class name'
+                'Key "filter" of a twig filter config should be a callable, '
+                . 'native function or fully qualified class name'
             ],
         ];
     }

--- a/test/TwigFilterFactoryTest.php
+++ b/test/TwigFilterFactoryTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-twigrenderer for the canonical source repository
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-twigrenderer/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Twig\TwigFilter;
+use Zend\Expressive\Twig\Exception\InvalidConfigException;
+use Zend\Expressive\Twig\TwigFilterFactory;
+
+class TwigFilterFactoryTest extends TestCase
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function testCanCreateForNativeFunctions(): void
+    {
+        $config = [
+            'name' => 'rot13',
+            'filter' => 'str_rot13',
+        ];
+
+        $filter = TwigFilterFactory::createFilterFromConfig($this->container->reveal(), $config);
+        $this->assertSame('rot13', $filter->getName());
+    }
+
+    public function testCanCreateForStaticMethods(): void
+    {
+        $config = [
+            'name' => 'rot13',
+            'filter' => 'str_rot13',
+        ];
+
+        $filter = TwigFilterFactory::createFilterFromConfig($this->container->reveal(), $config);
+        $this->assertSame('rot13', $filter->getName());
+    }
+
+    public function getInvalidConfig(): array
+    {
+        return [
+            [
+                ['bar'],
+                'Both "name" and "filter" keys are mandatory when defining twig filters'
+            ],
+            [
+                [ 'name' => 'bar' ],
+                'Both "name" and "filter" keys are mandatory when defining twig filters'
+            ],
+            [
+                [ 'name' => 'bar', 'options' => [] ],
+                'Both "name" and "filter" keys are mandatory when defining twig filters'
+            ],
+            [
+                [ 'name' => 'bar', 'filter' => true ],
+                'Key "filter" of a twig filter config should be a callable, native function or fully qualified class name'
+            ],
+            [
+                [ 'name' => 'bar', 'filter' => 42 ],
+                'Key "filter" of a twig filter config should be a callable, native function or fully qualified class name'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidConfig
+     * @param array $config
+     * @param string $message
+     */
+    public function testThrowsForInvalidConfig(array $config, string $message): void
+    {
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage($message);
+        TwigFilterFactory::createFilterFromConfig($this->container->reveal(), $config);
+    }
+
+    public function testCanCreateForCallable(): void
+    {
+        $config = [
+            'name' => 'barFilter',
+            'filter' => function ($input) {
+                return 'Hello '. $input;
+            },
+        ];
+
+        $filter = TwigFilterFactory::createFilterFromConfig($this->container->reveal(), $config);
+        $this->assertSame('barFilter', $filter->getName());
+    }
+
+    public function testCanCreateForNativeFunction(): void
+    {
+        $config = [
+            'name' => 'hash',
+            'filter' => 'sha1',
+        ];
+
+        $filter = TwigFilterFactory::createFilterFromConfig($this->container->reveal(), $config);
+        $this->assertSame('hash', $filter->getName());
+    }
+
+    public function testCanCreateForService(): void
+    {
+        $config = [
+            'name' => 'bazFilter',
+            'filter' => '\App\Twig\Filter\BazFilter',
+        ];
+        $this->container->has($config['filter'])->willReturn(true);
+        $filterStub = new TwigFilter(
+            'bazFilter',
+            function () {
+            }
+        );
+        $this->container->get($config['filter'])->willReturn($filterStub);
+
+        $filter = TwigFilterFactory::createFilterFromConfig($this->container->reveal(), $config);
+        $this->assertSame($filterStub, $filter);
+    }
+}


### PR DESCRIPTION
Hello.

Few days ago I wanted to render a `Money/Money` instance in a twig template something like below:

```
<div> {{ customer.balance|money }} </div>
```

and needed to attach an additional custom filter into `TwigEnvironment` to achieve this goal. Altering the state of the environment somewhere else after it's creation bugged me a bit then decided to extend the whole factory which sounds also bad:

```
class MyTwigEnvironmentFactory extends ExpressiveTwigEnvironmentFactory
{
    public function __invoke(ContainerInterface $container): Environment
    {
        $environment = parent::__invoke($container);
        $environment->addFilter( ... );

        return $environment;
```

My actual filter implementation was so simple:

```
$filter = new TwigFilter('money', function (Money $money) {
    $currencies = ['EUR' => 2, 'USD' => 2];
    $formatter = new DecimalMoneyFormatter(new CurrencyList($currencies));

    return $formatter->format($money); // 
 })
```

Then I thought that I am literally doing a lot to achieve relatively small task and decided to introduce ability to attach simple filters using configuration.

This PR provides required functionality to attach custom filters into environment instance via configuration like following:

```
'twig' => [
    'filters' => [
         // user defined filters
         ['name' => 'greet', 'filter' => function($a) { return 'Hello ' . $a; } ],
         ['name' => 'mul', 'filter' => 'Math::multiply', 'options' => ['needs_context' => true] ],
         ['name' => 'money', 'filter' => ['MoneyHelper', 'format'] ],
         ['name' => 'uglify', 'filter' => \Lib\Twig\Filter\Uglify::class ],
     ],
],
```

I am open to hear opinions of other contributors to improve the implementation further.

Official docs for Twig Filters: https://twig.symfony.com/doc/2.x/advanced.html#filters
