### PR TITLE
Allow for custom twig environment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Optional configuration can be stored in `config/autoload/templates.global.php`.
     'optimizations' => -1, // -1: Enable all (default), 0: disable optimizations
     'autoescape' => 'html', // Auto-escaping strategy [html|js|css|url|false]
     'auto_reload' => true, // Recompile the template whenever the source code changes
+    'debug' => true, // When set to true, the generated templates have a toString() method
+    'strict_variables' => true, // When set to true, twig throws an exception on invalid variables
 ],
 ```
 

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -95,14 +95,13 @@ class TwigEnvironmentFactory
 
         $debug    = (bool) ($config['debug'] ?? false);
         $config   = TwigRendererFactory::mergeConfig($config);
-        $cacheDir = $config['cache_dir'] ?? false;
 
         // Create the engine instance
         $loader      = new FilesystemLoader();
         $environment = new Environment($loader, [
-            'cache'            => $debug ? false : $cacheDir,
-            'debug'            => $debug,
-            'strict_variables' => $debug,
+            'cache'            => $config['cache_dir'] ?? false,
+            'debug'            => $config['debug'] ?? $debug,
+            'strict_variables' => $config['strict_variables'] ?? $debug,
             'auto_reload'      => $config['auto_reload'] ?? $debug,
             'optimizations'    => $config['optimizations'] ?? OptimizerNodeVisitor::OPTIMIZE_ALL,
             'autoescape'       => $config['autoescape'] ?? 'html',


### PR DESCRIPTION
While trying to override the default twig environment options today, I discovered with the current logic it is not possible to utilize development mode as well as a custom cache directory. This requested change will allow for individual custom twig environment config options.